### PR TITLE
Update Claude Code auth button label

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -90,7 +90,7 @@ export class ClaudeAcpAgent implements Agent {
       authMethods: [
         {
           description: "Run `claude /login` in the terminal",
-          name: "Login with Claude CLI",
+          name: "Log in with Claude Code",
           id: "claude-login",
         },
         {


### PR DESCRIPTION
We were using "Claude CLI" which is not the correct product name.