### PR TITLE
Remove dollar signs from CLI commands in installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Setup instructions for other clients are coming soon. Feel free to [submit a PR]
 Install the adapter from `npm`:
 
 ```bash
-$ npm install @zed-industries/claude-code-acp
+npm install @zed-industries/claude-code-acp
 ```
 
 You can then use `claude-code-acp` as a regular ACP agent:
 
 ```
-$ ANTHROPIC_API_KEY=sk-... claude-code-acp
+ANTHROPIC_API_KEY=sk-... claude-code-acp
 ```
 
 ## License


### PR DESCRIPTION
Makes it easier to copy and paste the installation commands without having to manually remove the dollar signs. This is a common convention in documentation to improve user experience when following installation instructions.