### PR TITLE
Support HTTP/SSE MCP servers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-code": "^1.0.100",
         "@modelcontextprotocol/sdk": "^1.17.4",
-        "@zed-industries/agent-client-protocol": "0.2.0-alpha.6",
+        "@zed-industries/agent-client-protocol": "0.2.0-alpha.7",
         "diff": "^8.0.2",
         "express": "^5.1.0",
         "minimist": "^1.2.8",
@@ -1808,9 +1808,9 @@
       }
     },
     "node_modules/@zed-industries/agent-client-protocol": {
-      "version": "0.2.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.2.0-alpha.6.tgz",
-      "integrity": "sha512-Mepcrp9ztLKRSkUuKJ7gnxIL1NRoGbSlY+BWr6WyhJ/sqcocaPSiINs0rt24RZGiU8E+TUwy5FNFW5T9tbIR1A==",
+      "version": "0.2.0-alpha.7",
+      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.2.0-alpha.7.tgz",
+      "integrity": "sha512-LusOBTbhX1veoL2IwUigWcCUf4r7Wl0nFJPeXoBx3OXTWCGE5WfmUPjpXVpduegxEipqea53Q/ls5lQfyoYd3Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.100",
     "@modelcontextprotocol/sdk": "^1.17.4",
-    "@zed-industries/agent-client-protocol": "0.2.0-alpha.6",
+    "@zed-industries/agent-client-protocol": "0.2.0-alpha.7",
     "diff": "^8.0.2",
     "express": "^5.1.0",
     "minimist": "^1.2.8",

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -86,6 +86,10 @@ export class ClaudeAcpAgent implements Agent {
           image: true,
           embeddedContext: true,
         },
+        mcpCapabilities: {
+          http: true,
+          sse: true,
+        },
       },
       authMethods: [
         {
@@ -110,14 +114,24 @@ export class ClaudeAcpAgent implements Agent {
     const mcpServers: Record<string, McpServerConfig> = {};
     if (Array.isArray(params.mcpServers)) {
       for (const server of params.mcpServers) {
-        mcpServers[server.name] = {
-          type: "stdio",
-          command: server.command,
-          args: server.args,
-          env: server.env
-            ? Object.fromEntries(server.env.map((e) => [e.name, e.value]))
-            : undefined,
-        };
+        if ("type" in server) {
+          mcpServers[server.name] = {
+            type: server.type,
+            url: server.url,
+            headers: server.headers
+              ? Object.fromEntries(server.headers.map((e) => [e.name, e.value]))
+              : undefined,
+          };
+        } else {
+          mcpServers[server.name] = {
+            type: "stdio",
+            command: server.command,
+            args: server.args,
+            env: server.env
+              ? Object.fromEntries(server.env.map((e) => [e.name, e.value]))
+              : undefined,
+          };
+        }
       }
     }
 


### PR DESCRIPTION
HTTP/SSE MCP servers can be now included in `session/new`