### PR TITLE
Support plan mode and all other permission modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/claude-code": "^1.0.100",
         "@modelcontextprotocol/sdk": "^1.17.4",
-        "@zed-industries/agent-client-protocol": "0.2.0-alpha.7",
+        "@zed-industries/agent-client-protocol": "0.2.0-alpha.8",
         "diff": "^8.0.2",
         "express": "^5.1.0",
         "minimist": "^1.2.8",
@@ -1808,9 +1808,9 @@
       }
     },
     "node_modules/@zed-industries/agent-client-protocol": {
-      "version": "0.2.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.2.0-alpha.7.tgz",
-      "integrity": "sha512-LusOBTbhX1veoL2IwUigWcCUf4r7Wl0nFJPeXoBx3OXTWCGE5WfmUPjpXVpduegxEipqea53Q/ls5lQfyoYd3Q==",
+      "version": "0.2.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@zed-industries/agent-client-protocol/-/agent-client-protocol-0.2.0-alpha.8.tgz",
+      "integrity": "sha512-60DDfM5ghChYkbz0Nk2nWDuWQ/BOpU+/4BcIgzHYhEQvCcJRbcs5piVjTXx7TryHNTOTyCmLmoX/WRpAZtva/Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "zod": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@anthropic-ai/claude-code": "^1.0.100",
     "@modelcontextprotocol/sdk": "^1.17.4",
-    "@zed-industries/agent-client-protocol": "0.2.0-alpha.7",
+    "@zed-industries/agent-client-protocol": "0.2.0-alpha.8",
     "diff": "^8.0.2",
     "express": "^5.1.0",
     "minimist": "^1.2.8",

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -207,10 +207,26 @@ export class ClaudeAcpAgent implements Agent {
       modes: {
         currentModeId: "default",
         availableModes: [
-          { id: "default", name: "Default" },
-          { id: "acceptEdits", name: "Accept Edits" },
-          { id: "bypassPermissions", name: "Bypass Permissions" },
-          { id: "plan", name: "Plan" },
+          {
+            id: "default",
+            name: "Always Ask",
+            description: "Prompts for permission on first use of each tool",
+          },
+          {
+            id: "acceptEdits",
+            name: "Accept Edits",
+            description: "Automatically accepts file edit permissions for the session",
+          },
+          {
+            id: "bypassPermissions",
+            name: "Bypass Permissions",
+            description: "Skips all permission prompts",
+          },
+          {
+            id: "plan",
+            name: "Plan Mode",
+            description: "Claude can analyze but not modify files or execute commands",
+          },
         ],
       },
     };

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -622,7 +622,6 @@ File editing instructions:
         message: "Session not found",
       };
     }
-    console.log(JSON.stringify({ input, permissionMode: session.permissionMode }, null, 2));
 
     if (input.tool_name === "ExitPlanMode") {
       const response = await agent.client.requestPermission({

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -403,7 +403,7 @@ export function toolInfoFromToolUse(
     case "ExitPlanMode":
       return {
         title: "Ready to code?",
-        kind: "mode_switch",
+        kind: "switch_mode",
         content:
           input && input.plan
             ? [{ type: "content", content: { type: "text", text: input.plan } }]
@@ -490,6 +490,10 @@ export function toolUpdateFromToolResult(
         return toAcpContentUpdate(toolResult.content);
       }
       return {};
+    }
+
+    case "ExitPlanMode": {
+      return { title: "Exited Plan Mode" };
     }
 
     case "Task":

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,7 +4,7 @@ import {
   ToolCallLocation,
   ToolKind,
 } from "@zed-industries/agent-client-protocol";
-import { replaceAndCalculateLocation, SYSTEM_REMINDER } from "./mcp-server.js";
+import { replaceAndCalculateLocation, SYSTEM_REMINDER, toolNames } from "./mcp-server.js";
 
 interface ToolInfo {
   title: string;
@@ -67,7 +67,7 @@ export function toolInfoFromToolUse(
       };
 
     case "Bash":
-    case "mcp__acp__Bash":
+    case toolNames.bash:
       return {
         title: input?.command ? "`" + input.command.replaceAll("`", "\\`") + "`" : "Terminal",
         kind: "execute",
@@ -83,7 +83,7 @@ export function toolInfoFromToolUse(
       };
 
     case "BashOutput":
-    case "mcp__acp__BashOutput":
+    case toolNames.bashOutput:
       return {
         title: "Tail Logs",
         kind: "execute",
@@ -91,14 +91,14 @@ export function toolInfoFromToolUse(
       };
 
     case "KillBash":
-    case "mcp__acp__KillBash":
+    case toolNames.killBash:
       return {
         title: "Kill Process",
         kind: "execute",
         content: [],
       };
 
-    case "mcp__acp__read": {
+    case toolNames.read: {
       let limit = "";
       if (input.limit) {
         limit =
@@ -135,7 +135,7 @@ export function toolInfoFromToolUse(
         locations: [],
       };
 
-    case "mcp__acp__edit":
+    case toolNames.edit:
     case "Edit": {
       const path = input?.abs_path ?? input?.file_path;
       let oldText = input.old_string ?? null;
@@ -181,7 +181,7 @@ export function toolInfoFromToolUse(
       };
     }
 
-    case "mcp__acp__multi-edit":
+    case toolNames.multiEdit:
     case "MultiEdit": {
       const multiInput = input as {
         file_path: string;
@@ -234,7 +234,7 @@ export function toolInfoFromToolUse(
           : [],
       };
     }
-    case "mcp__acp__write": {
+    case toolNames.write: {
       let content: ToolCallContent[] = [];
       if (input && input.abs_path) {
         content = [
@@ -400,10 +400,10 @@ export function toolInfoFromToolUse(
         content: [],
       };
 
-    case "exit_plan_mode":
+    case "ExitPlanMode":
       return {
-        title: "Exit Plan Mode",
-        kind: "think",
+        title: "Ready to code?",
+        kind: "mode_switch",
         content:
           input && input.plan
             ? [{ type: "content", content: { type: "text", text: input.plan } }]
@@ -447,7 +447,7 @@ export function toolUpdateFromToolResult(
 ): ToolUpdate {
   switch (toolUse?.name) {
     case "Read":
-    case "mcp__acp__read":
+    case toolNames.read:
       if (Array.isArray(toolResult.content) && toolResult.content.length > 0) {
         return {
           content: toolResult.content.map((content: any) => ({
@@ -476,14 +476,14 @@ export function toolUpdateFromToolResult(
       }
       return {};
 
-    case "mcp__acp__Bash":
-    case "mcp__acp__edit":
+    case toolNames.bash:
     case "edit":
     case "Edit":
-    case "mcp__acp__multi-edit":
+    case toolNames.edit:
+    case toolNames.multiEdit:
     case "multi-edit":
     case "MultiEdit":
-    case "mcp__acp__write":
+    case toolNames.write:
     case "Write": {
       if (toolResult.is_error && toolResult.content?.length > 0) {
         // Only return errors


### PR DESCRIPTION
Exposes all Claude Code permission modes as [ACP Session modes](https://github.com/zed-industries/agent-client-protocol/pull/67). This allows ACP clients to build mode selectors and to be notified when the mode changes as a result of `ExitPlanMode`.

See a demo in the [Zed PR](https://github.com/zed-industries/zed/pull/37632).

Closes #31 