### PR TITLE
Re-upgrade to SDK version 1.0.111

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@anthropic-ai/claude-code": "^1.0.100",
-        "@modelcontextprotocol/sdk": "^1.17.4",
+        "@anthropic-ai/claude-code": "1.0.111",
+        "@modelcontextprotocol/sdk": "1.17.4",
         "@zed-industries/agent-client-protocol": "0.2.0-alpha.8",
-        "diff": "^8.0.2",
-        "express": "^5.1.0",
-        "minimist": "^1.2.8",
+        "diff": "8.0.2",
+        "express": "5.1.0",
+        "minimist": "1.2.8",
         "uuid": "11.1.0"
       },
       "bin": {
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.5.tgz",
-      "integrity": "sha512-QakrKIGniGuRVfWBdMsDea/dx1PNE739QJ7gCM41s9q+qaCYTHCdsIBXQVVXry3mfWAiaM9kT22Hyz53Uw8mfg==",
+      "version": "1.17.4",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.17.4.tgz",
+      "integrity": "sha512-zq24hfuAmmlNZvik0FLI58uE5sriN0WWsQzIlYnzSuKDAHFqJtBFrl/LfB1NLgJT5Y7dEBzaX4yAKqOPrcetaw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
   "author": "Zed Industries",
   "license": "Apache-2.0",
   "dependencies": {
-    "@anthropic-ai/claude-code": "^1.0.100",
-    "@modelcontextprotocol/sdk": "^1.17.4",
+    "@anthropic-ai/claude-code": "1.0.111",
+    "@modelcontextprotocol/sdk": "1.17.4",
     "@zed-industries/agent-client-protocol": "0.2.0-alpha.8",
-    "diff": "^8.0.2",
-    "express": "^5.1.0",
-    "minimist": "^1.2.8",
+    "diff": "8.0.2",
+    "express": "5.1.0",
+    "minimist": "1.2.8",
     "uuid": "11.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
There's apparently a RCE on 1.0.100, so we shouldn't stay on that version.