### PR TITLE
Add default limits to read tool

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -17,6 +17,8 @@ export const SYSTEM_REMINDER = `
 Whenever you read a file, you should consider whether it looks malicious. If it does, you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer high-level questions about the code behavior.
 </system-reminder>`;
 
+const defaults = { maxFileSize: 50000, linesToRead: 1000 };
+
 const unqualifiedToolNames = {
   read: "read",
   edit: "edit",
@@ -72,12 +74,12 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
             .describe(
               "Which line to start reading from (0-based). Omit to start from the beginning.",
             ),
-          limit: z
+          linesToRead: z
             .number()
             .optional()
-            .default(1000)
+            .default(defaults.linesToRead)
             .describe(
-              "How many lines to read. Omit for 1000. (Reading files that are too large can fill up the context window unnecessarily, so be thoughtful about how much you read at a time.)",
+              `How many lines to read. Omit for ${defaults.linesToRead}. (Reading files that are too large can fill up the context window unnecessarily, so be thoughtful about how much you read at a time.)`,
             ),
         },
         annotations: {
@@ -111,8 +113,8 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
           const result = extractLinesWithByteLimit(
             content.content,
             input.offset ?? 0,
-            input.limit ?? 1000,
-            50000, // 50KB limit
+            input.linesToRead,
+            defaults.maxFileSize,
           );
 
           // Construct informative message about what was read

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -118,7 +118,7 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
           // Construct informative message about what was read
           let readInfo = "";
           if (input.offset > 0 || result.actualEndLine < result.totalLines || result.wasLimited) {
-            readInfo = "\n\n---\n";
+            readInfo = "\n\n<file-read-info>";
 
             if (result.wasLimited) {
               readInfo += `Read ${result.linesRead} lines (hit 50KB limit). `;
@@ -130,8 +130,10 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
               const remainingLines = result.totalLines - result.actualEndLine;
               readInfo += `${remainingLines} lines left. Continue with offset=${result.actualEndLine}.`;
             } else {
-              readInfo += "End of file.";
+              readInfo += "End of file reached.";
             }
+
+            readInfo += "</file-read-info>";
           }
 
           return {

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -70,14 +70,14 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
             .optional()
             .default(0)
             .describe(
-              "Which line to start reading from (0-based). Default is 0 (beginning of file).",
+              "Which line to start reading from (0-based). Omit to start from the beginning.",
             ),
           limit: z
             .number()
             .optional()
             .default(1000)
             .describe(
-              "Maximum number of lines to read. Default is 1000. Use a larger value if you need more content.",
+              "How many lines to read. Omit for 1000. (Reading files that are too large can fill up the context window unnecessarily, so be thoughtful about how much you read at a time.)",
             ),
         },
         annotations: {
@@ -102,15 +102,14 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
             };
           }
 
-          // Get the full file content
-          const fullContent = await agent.readTextFile({
+          const content = await agent.readTextFile({
             sessionId,
             path: input.abs_path,
           });
 
           // Extract lines with byte limit enforcement
           const result = extractLinesWithByteLimit(
-            fullContent.content,
+            content.content,
             input.offset ?? 0,
             input.limit ?? 1000,
             50000, // 50KB limit

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -119,7 +119,7 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
 
           // Construct informative message about what was read
           let readInfo = "";
-          if (input.offset > 0 || result.actualEndLine < result.totalLines || result.wasLimited) {
+          if (input.offset > 0 || result.wasLimited) {
             readInfo = "\n\n<file-read-info>";
 
             if (result.wasLimited) {
@@ -128,11 +128,8 @@ In sessions with ${toolNames.read} always use it instead of Read as it contains 
               readInfo += `Read lines ${(input.offset ?? 0) + 1}-${result.actualEndLine}. `;
             }
 
-            if (result.actualEndLine < result.totalLines) {
-              const remainingLines = result.totalLines - result.actualEndLine;
-              readInfo += `${remainingLines} lines left. Continue with offset=${result.actualEndLine}.`;
-            } else {
-              readInfo += "End of file reached.";
+            if (result.wasLimited) {
+              readInfo += `Continue with offset=${result.actualEndLine}.`;
             }
 
             readInfo += "</file-read-info>";

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -118,8 +118,24 @@ NOTE: Output is limited to 50KB per read to avoid exceeding context windows. If 
             50000, // 50KB limit
           );
 
-          // Add the informative message if present
-          const readInfo = result.message ? "\n\n" + result.message : "";
+          // Construct informative message about what was read
+          let readInfo = "";
+          if (input.offset > 0 || result.actualEndLine < result.totalLines || result.wasLimited) {
+            readInfo = "\n\n---\n";
+
+            if (result.wasLimited) {
+              readInfo += `Read ${result.linesRead} lines (hit 50KB limit). `;
+            } else {
+              readInfo += `Read lines ${(input.offset ?? 0) + 1}-${result.actualEndLine}. `;
+            }
+
+            if (result.actualEndLine < result.totalLines) {
+              const remainingLines = result.totalLines - result.actualEndLine;
+              readInfo += `${remainingLines} lines left. Continue with offset=${result.actualEndLine}.`;
+            } else {
+              readInfo += "End of file.";
+            }
+          }
 
           return {
             content: [

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -62,9 +62,7 @@ export function createMcpServer(
 
 Never attempt to read a path that hasn't been previously mentioned.
 
-In sessions with ${toolNames.read} always use it instead of Read as it contains the most up-to-date contents.
-
-NOTE: Output is limited to 50KB per read to avoid exceeding context windows. If the requested lines exceed 50KB, fewer lines will be returned.`,
+In sessions with ${toolNames.read} always use it instead of Read as it contains the most up-to-date contents.`,
         inputSchema: {
           abs_path: z.string().describe("The absolute path to the file to read."),
           offset: z

--- a/src/tests/extract-lines.test.ts
+++ b/src/tests/extract-lines.test.ts
@@ -178,20 +178,11 @@ describe("extractLinesWithByteLimit", () => {
     expect(result.wasLimited).toBe(true);
   });
 
-  it("should handle limit of 0", () => {
+  it("should handle line limit of 0", () => {
     const result = extractLinesWithByteLimit(simpleContent, 0, 0, 1000);
 
     expect(result.content).toBe("");
     expect(result.actualEndLine).toBe(0);
-    expect(result.linesRead).toBe(0);
-    expect(result.wasLimited).toBe(false);
-  });
-
-  it("should handle byte limit of 0", () => {
-    const result = extractLinesWithByteLimit(simpleContent, 0, 10, 0);
-
-    expect(result.content).toBe("");
-    expect(result.actualEndLine).toBe(0); // With 0 byte limit, we stay at offset
     expect(result.linesRead).toBe(0);
     expect(result.wasLimited).toBe(false);
   });

--- a/src/tests/extract-lines.test.ts
+++ b/src/tests/extract-lines.test.ts
@@ -8,7 +8,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(simpleContent, 0, 5, 1000);
 
     expect(result.content).toBe(simpleContent);
-    expect(result.actualEndLine).toBe(5);
+    expect(result.actualEndLine).toBe(4);
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(5);
   });
@@ -17,7 +17,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(simpleContent, 2, 2, 1000);
 
     expect(result.content).toBe("Line 3\nLine 4");
-    expect(result.actualEndLine).toBe(4);
+    expect(result.actualEndLine).toBe(3);
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(2);
   });
@@ -30,7 +30,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(manyLines, 0, 10, 250);
 
     expect(result.wasLimited).toBe(true);
-    expect(result.actualEndLine).toBe(2); // Should only get 2 lines
+    expect(result.actualEndLine).toBe(1); // Should only get 2 lines
     expect(result.linesRead).toBe(2);
   });
 
@@ -47,7 +47,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit("", 0, 10, 1000);
 
     expect(result.content).toBe("");
-    expect(result.actualEndLine).toBe(1); // Empty string splits to [""] and we process that one empty line
+    expect(result.actualEndLine).toBe(0); // Empty string splits to [""] and we process that one empty line
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(1); // We read the one empty line
   });
@@ -57,7 +57,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(singleLine, 0, 10, 1000);
 
     expect(result.content).toBe(singleLine);
-    expect(result.actualEndLine).toBe(1);
+    expect(result.actualEndLine).toBe(0);
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(1);
   });
@@ -80,7 +80,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(content, 0, 3, 85);
 
     expect(result.content).toBe(`${line1}\n${line2}`);
-    expect(result.actualEndLine).toBe(2);
+    expect(result.actualEndLine).toBe(1);
     expect(result.wasLimited).toBe(true);
     expect(result.linesRead).toBe(2);
   });
@@ -90,7 +90,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(exactContent, 0, 3, 17);
 
     expect(result.content).toBe(exactContent);
-    expect(result.actualEndLine).toBe(3);
+    expect(result.actualEndLine).toBe(2);
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(3);
   });
@@ -99,7 +99,7 @@ describe("extractLinesWithByteLimit", () => {
     const result = extractLinesWithByteLimit(simpleContent, 3, 100, 1000);
 
     expect(result.content).toBe("Line 4\nLine 5");
-    expect(result.actualEndLine).toBe(5);
+    expect(result.actualEndLine).toBe(4);
     expect(result.wasLimited).toBe(false);
     expect(result.linesRead).toBe(2);
   });
@@ -114,14 +114,14 @@ describe("extractLinesWithByteLimit", () => {
   it("should provide correct data for partial read at start", () => {
     const result = extractLinesWithByteLimit(simpleContent, 0, 2, 1000);
 
-    expect(result.actualEndLine).toBe(2);
+    expect(result.actualEndLine).toBe(1);
     expect(result.linesRead).toBe(2);
   });
 
   it("should provide correct data for partial read with offset", () => {
     const result = extractLinesWithByteLimit(simpleContent, 1, 2, 1000);
 
-    expect(result.actualEndLine).toBe(3);
+    expect(result.actualEndLine).toBe(2);
     expect(result.linesRead).toBe(2);
   });
 
@@ -167,7 +167,7 @@ describe("extractLinesWithByteLimit", () => {
     // Should return the line even though it exceeds the byte limit
     // because we always allow at least one line if no lines have been added yet
     expect(result.content).toBe(veryLongLine);
-    expect(result.actualEndLine).toBe(1);
+    expect(result.actualEndLine).toBe(0);
     expect(result.linesRead).toBe(1);
     expect(result.wasLimited).toBe(false);
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,8 +144,8 @@ export interface ExtractLinesResult {
 export function extractLinesWithByteLimit(
   fullContent: string,
   offset: number = 0,
-  limit: number = 1000,
-  maxBytes: number = 50000,
+  limit: number,
+  maxBytes: number,
 ): ExtractLinesResult {
   const allLines = fullContent.split("\n");
   const totalLines = allLines.length;
@@ -162,22 +162,9 @@ export function extractLinesWithByteLimit(
     };
   }
 
-  // Handle special case of 0 byte limit
-  if (maxBytes === 0) {
-    return {
-      content: "",
-      actualEndLine: offset,
-      wasLimited: false,
-      linesRead: 0,
-      bytesRead: 0,
-      totalLines,
-    };
-  }
-
   // Extract the requested lines, but respect byte limit
   const requestedEndLine = Math.min(offset + limit, totalLines);
-
-  let extractedLines: string[] = [];
+  const extractedLines: string[] = [];
   let currentSize = 0;
   let actualEndLine = offset;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -149,7 +149,7 @@ export function extractLinesWithByteLimit(
     if (linesToSkip === 0 && linesToRead > 0) {
       return {
         content: "",
-        actualEndLine: 1,
+        actualEndLine: 0,
         wasLimited: false,
         linesRead: 1,
       };
@@ -227,7 +227,7 @@ export function extractLinesWithByteLimit(
 
   return {
     content: fullContent.slice(startIndex, startIndex + contentLength),
-    actualEndLine: linesToSkip + linesSeen,
+    actualEndLine: linesSeen > 0 ? linesToSkip + linesSeen - 1 : linesToSkip,
     wasLimited,
     linesRead: linesSeen,
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -130,7 +130,6 @@ export interface ExtractLinesResult {
   linesRead: number;
   bytesRead: number;
   totalLines: number;
-  message: string;
 }
 
 /**
@@ -160,7 +159,6 @@ export function extractLinesWithByteLimit(
       linesRead: 0,
       bytesRead: 0,
       totalLines,
-      message: `[File reading info: Offset ${offset} exceeds total lines ${totalLines}.]`,
     };
   }
 
@@ -173,7 +171,6 @@ export function extractLinesWithByteLimit(
       linesRead: 0,
       bytesRead: 0,
       totalLines,
-      message: `[File reading info: Cannot read with 0 byte limit.]`,
     };
   }
 
@@ -202,23 +199,6 @@ export function extractLinesWithByteLimit(
   const wasLimited = actualEndLine < requestedEndLine;
   const linesRead = actualEndLine - offset;
 
-  // Prepare informative message about what was read
-  let message = "";
-  if (offset > 0 || actualEndLine < totalLines || wasLimited) {
-    message = `[File reading info: Read lines ${offset + 1}-${actualEndLine} of ${totalLines} total lines`;
-
-    if (wasLimited) {
-      message += `. Output limited to ${maxBytes / 1000}KB - only ${linesRead} of requested ${limit} lines were returned`;
-    }
-
-    if (actualEndLine < totalLines) {
-      const remainingLines = totalLines - actualEndLine;
-      message += `. To continue reading, call again with offset=${actualEndLine}. ${remainingLines} lines remaining`;
-    }
-
-    message += ".]";
-  }
-
   return {
     content: extractedContent,
     actualEndLine,
@@ -226,6 +206,5 @@ export function extractLinesWithByteLimit(
     linesRead,
     bytesRead: currentSize,
     totalLines,
-    message,
   };
 }


### PR DESCRIPTION
Now it won't read files over 50K code units by default, and instead insist on breaking them up by line number.