### PR TITLE
Tool error backticks

### DIFF
--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -778,7 +778,10 @@ describe("tool conversions", () => {
     // Should return empty object when parsing fails
     expect(update).toEqual({
       content: [
-        { content: { type: "text", text: "Failed to find `old_string`" }, type: "content" },
+        {
+          content: { type: "text", text: "```\nFailed to find `old_string`\n```" },
+          type: "content",
+        },
       ],
     });
   });


### PR DESCRIPTION
This looks more reasonable now, because the code is now rendered in a monospace font:

<img width="475" height="450" alt="Screenshot 2025-09-15 at 10 58 20 AM" src="https://github.com/user-attachments/assets/9870436b-ee8f-44cd-b814-b22ad9261ebe" />

That said, this definitely would benefit from a horizontal scroll bar on the code blocks. You can't really read what it's saying without copying the text out of the block.

Of course, in this particular case the relevant info is all in the beginning of the error message (namely, that it failed to find the `old_string`), and this does look overall better than before (where it was just this big jumble of non-monospaced code), so I think it's worth merging as-is and then revisiting horizontal scrolling later.