### PR TITLE
Add back @anthropic-ai/claude-code as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+- Add back @anthropic-ai/claude-code@2.0.1 as runtime dependency
+
 ## 0.5.1
 
 - Update to @anthropic-ai/claude-agent-sdk@v0.1.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@zed-industries/claude-code-acp",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zed-industries/claude-code-acp",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "0.1.1",
+        "@anthropic-ai/claude-code": "2.0.1",
         "@modelcontextprotocol/sdk": "1.18.2",
         "@zed-industries/agent-client-protocol": "0.4.3",
         "diff": "8.0.2",
@@ -43,6 +44,26 @@
       "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.1.1.tgz",
       "integrity": "sha512-+12GQktMFc5Uqz6oVjJbj7Q+GD5QDorKEKtInALKD7VleJwLlFbMYIlm4586owIV5veFvb6bAVofKn9CnYWtvw==",
       "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.5",
+        "@img/sharp-darwin-x64": "^0.33.5",
+        "@img/sharp-linux-arm": "^0.33.5",
+        "@img/sharp-linux-arm64": "^0.33.5",
+        "@img/sharp-linux-x64": "^0.33.5",
+        "@img/sharp-win32-x64": "^0.33.5"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-code": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-code/-/claude-code-2.0.1.tgz",
+      "integrity": "sha512-2SboYcdJ+dsE2K784dbJ4ohVWlAkLZhU7mZG1lebyG6TvGLXLhjc2qTEfCxSeelCjJHhIh/YkNpe06veB4IgBw==",
+      "license": "SEE LICENSE IN README.md",
+      "bin": {
+        "claude": "cli.js"
+      },
       "engines": {
         "node": ">=18.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "bin": {
     "claude-code-acp": "./dist/index.js"
   },
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "An ACP-compatible coding agent powered by the Claude Code SDK (TypeScript)",
   "main": "dist/index.js",
   "type": "module",
@@ -52,6 +52,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.1.1",
+    "@anthropic-ai/claude-code": "2.0.1",
     "@modelcontextprotocol/sdk": "1.18.2",
     "@zed-industries/agent-client-protocol": "0.4.3",
     "diff": "8.0.2",


### PR DESCRIPTION
Some clients (i.e. Zed) still relied on this package being there at runtime.
Adding it as a dependency for now.
