### PR TITLE
Improve setSessionMode error handling for SDK messages

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -383,10 +383,22 @@ export class ClaudeAcpAgent implements Agent {
       case "bypassPermissions":
       case "plan":
         this.sessions[params.sessionId].permissionMode = params.modeId;
-        await this.sessions[params.sessionId].query.setPermissionMode(params.modeId);
+        try {
+          await this.sessions[params.sessionId].query.setPermissionMode(params.modeId);
+        } catch (error) {
+          const errorMessage =
+            error instanceof Error && error.message ? error.message : "Invalid Mode";
+          if (params.modeId === "bypassPermissions") {
+            throw new Error(
+              `Failed to enable bypass permissions mode. This mode requires proper Claude Code configuration. Original error: ${errorMessage}`,
+            );
+          }
+
+          throw new Error(errorMessage);
+        }
         return {};
       default:
-        throw new Error("Invalid mode");
+        throw new Error("Invalid Mode");
     }
   }
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -769,6 +769,22 @@ describe("tool conversions", () => {
   });
 });
 
+describe("setSessionMode bypass permissions error handling", () => {
+  it("should handle bypass permissions errors by wrapping the original SDK error", () => {
+    const originalError = new Error("Some SDK error message");
+
+    const simulateBypassPermissionError = (error: Error) => {
+      throw new Error(
+        `Failed to enable bypass permissions mode. This mode requires proper Claude Code configuration. Original error: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    };
+
+    expect(() => simulateBypassPermissionError(originalError)).toThrow(
+      "Failed to enable bypass permissions mode. This mode requires proper Claude Code configuration. Original error: Some SDK error message",
+    );
+  });
+});
+
 describe("escape markdown", () => {
   it("should escape markdown characters", () => {
     let text = "Hello *world*!";


### PR DESCRIPTION
When `default`, `acceptEdits`, or `plan` modes fail, users see the real error from the SDK instead of a generic message.

`Bypass permissions` gets special treatment - it shows both the SDK error AND explains it needs proper configuration. I couldn't test SDK thats why I added special treatment for bypass permissions. If you can test it we can talk further.

Related to: https://github.com/zed-industries/zed/pull/39524 @benbrandt 