### PR TITLE
Enable setting CLAUDE_CODE_EXECUTABLE to override the claude code CLI used

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -179,6 +179,9 @@ export class ClaudeAcpAgent implements Agent {
       // note: although not documented by the types, passing an absolute path
       // here works to find zed's managed node version.
       executable: process.execPath as any,
+      ...(process.env.CLAUDE_CODE_EXECUTABLE && {
+        pathToClaudeCodeExecutable: process.env.CLAUDE_CODE_EXECUTABLE,
+      }),
     };
 
     const allowedTools = [];


### PR DESCRIPTION
## Description
Closes #84 by allowing users to set `CLAUDE_CODE_EXECUTABLE` to override the binary that's used by the claude code SDK. This is key in enterprise environments where claude CLI has been shimmed in some way.

