### PR TITLE
Add support for appending or overriding the system prompt

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -169,19 +169,24 @@ export class ClaudeAcpAgent implements Agent {
       },
     };
 
-    let systemPrompt: Options["systemPrompt"] =  { type: "preset", preset: "claude_code" }
-    if (params._meta?.systemPrompt){
-      if (typeof params._meta.systemPrompt === "string") {
-        systemPrompt = params._meta.systemPrompt
-      } else {
-        systemPrompt = {...systemPrompt, ...params._meta.systemPrompt}
+    let systemPrompt: Options["systemPrompt"] = { type: "preset", preset: "claude_code" };
+    if (params._meta?.systemPrompt) {
+      const customPrompt = params._meta.systemPrompt;
+      if (typeof customPrompt === "string") {
+        systemPrompt = customPrompt;
+      } else if (
+        typeof customPrompt === "object" &&
+        "append" in customPrompt &&
+        typeof customPrompt.append === "string"
+      ) {
+        systemPrompt.append = customPrompt.append;
       }
     }
 
     const options: Options = {
       cwd: params.cwd,
       mcpServers,
-      systemPrompt: systemPrompt,
+      systemPrompt,
       settingSources: ["user", "project", "local"],
       permissionPromptToolName: PERMISSION_TOOL_NAME,
       stderr: (err) => console.error(err),


### PR DESCRIPTION
resolves #90 

Tested both the `append` and `override` flows by sending:
```javascript
const resp = await this.connection.newSession({
			cwd: basePath,
			_meta: {
				systemPrompt: "you are an obsidian assistant agent, you should be helpful to the user when working with their notes"
			},
			mcpServers: []
		});
```

```javascript
const resp = await this.connection.newSession({
			cwd: basePath,
			_meta: {
				systemPrompt: {
					append: "always speak in spanish"
				}
			},
			mcpServers: []
		});
```

and confirmed that in both cases those prompts are what gets sent to the agent!