### PR TITLE
Make write and edit permissions consistent

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -191,7 +191,6 @@ export class ClaudeAcpAgent implements Agent {
       disallowedTools.push("Read");
     }
     if (this.clientCapabilities?.fs?.writeTextFile) {
-      allowedTools.push(toolNames.write, toolNames.edit);
       disallowedTools.push("Write", "Edit");
     }
     if (this.clientCapabilities?.terminal) {


### PR DESCRIPTION
Currently edit requires a permissions call and write does not. This means that if clients want to allow users to approve `Write` calls they need to add handling to `HandleFileWrite` but if they do that then edits get _two_ permissions checks.

Alternatively we could remove the write tool from approved tools (which would make more sense to me) but I'm assuming its there for a good reason, if not happy to change to remove it instead!