### PR TITLE
agent: Skip duplicate assistant messages from stream events

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -398,6 +398,11 @@ export class ClaudeAcpAgent implements Agent {
             break;
           }
 
+          // Skip assistant messages with string content - already handled by stream events
+          if (message.type === "assistant" && typeof message.message.content === "string") {
+            break;
+          }
+
           if (
             message.type === "assistant" &&
             message.message.model === "<synthetic>" &&


### PR DESCRIPTION
The SDK occasionally emits assistant messages with string content after already emitting the same content via stream events. This caused duplicate text to appear in the output.

Add logic to skip assistant messages with string content since they have already been handled by the streaming events. Include a test that verifies this behavior by simulating the SDK's emission pattern.

I've seen this happen in Zed, see screenshot below. Note that this is quite intermittent and so reasonably difficult to replicate, once every couple of conversations and usually only a few characters.

<img width="406" height="173" alt="image" src="https://github.com/user-attachments/assets/499193fa-a9fa-4357-a831-4f982b6a8e14" />

This was tracked down and fixed with help from CC and Codex. I'm not particularly familiar with the SDK myself.
