### PR TITLE
Fix type holes in switch statements

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -334,8 +334,11 @@ export class ClaudeAcpAgent implements Agent {
               break;
             case "compact_boundary":
               break;
+            case "hook_response":
+              // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
+              break;
             default:
-              unreachable(message as never);
+              unreachable(message);
           }
           break;
         case "result": {
@@ -427,7 +430,7 @@ export class ClaudeAcpAgent implements Agent {
           break;
         }
         default:
-          unreachable(message as never);
+          unreachable(message);
       }
     }
     throw new Error("Session did not end in result");


### PR DESCRIPTION
We were relying on unreachable to catch stuff for us, but it wasn't erroring because we were manually casting a few of the types to never, leading to a bug when a hook response was encountered.

We'll revisit showing these hook responses to the user once ACP supports multiple types of status messages.
