### PR TITLE
Report errors from "status" messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.10.5
 
+- Better error messages at end of turn if there were any
 - Add experimental support for disabling built-in tools via \_meta flag
 - Update to @anthropic-ai/claude-agent-sdk@v0.1.44
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -408,13 +408,28 @@ export class ClaudeAcpAgent implements Agent {
               if (message.result.includes("Please run /login")) {
                 throw RequestError.authRequired();
               }
+              if (message.is_error) {
+                throw RequestError.internalError(undefined, message.result);
+              }
               return { stopReason: "end_turn" };
             }
             case "error_during_execution":
+              if (message.is_error) {
+                throw RequestError.internalError(
+                  undefined,
+                  message.errors.join(", ") || message.subtype,
+                );
+              }
               return { stopReason: "end_turn" };
             case "error_max_budget_usd":
             case "error_max_turns":
             case "error_max_structured_output_retries":
+              if (message.is_error) {
+                throw RequestError.internalError(
+                  undefined,
+                  message.errors.join(", ") || message.subtype,
+                );
+              }
               return { stopReason: "max_turn_requests" };
             default:
               unreachable(message);


### PR DESCRIPTION
The "status" message may say "success" but can actually have an error
which we weren't surfacing.

We should now be returning a more helpful message to the user.

Closes #161 and possibly #146
