### PR TITLE
Disable experimental terminal auth support for now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.6
+
+- Disable experimental terminal auth support for now, as it was causing issues on Windows. Will revisit with a fix later.
+
 ## 0.10.5
 
 - Better error messages at end of turn if there were any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@zed-industries/claude-code-acp",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@zed-industries/claude-code-acp",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.5.1",
@@ -4497,6 +4497,7 @@
       "integrity": "sha512-BxAKBWmIbrDgrokdGZH1IgkIk/5mMHDreLDmCJ0qpyJaAteP8NvMhkwr/ZCQNqNH97bw/dANTE9PDzqwJghfMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.10.5",
+  "version": "0.10.6",
   "description": "An ACP-compatible coding agent powered by the Claude Code SDK (TypeScript)",
   "main": "dist/lib.js",
   "bin": {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -53,7 +53,6 @@ import {
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
 import packageJson from "../package.json" with { type: "json" };
-import { fileURLToPath } from "node:url";
 
 type Session = {
   query: Query;
@@ -124,17 +123,17 @@ export class ClaudeAcpAgent implements Agent {
     };
 
     // If client supports terminal-auth capability, use that instead.
-    if (request.clientCapabilities?._meta?.["terminal-auth"] === true) {
-      const cliPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk/cli.js"));
+    // if (request.clientCapabilities?._meta?.["terminal-auth"] === true) {
+    //   const cliPath = fileURLToPath(import.meta.resolve("@anthropic-ai/claude-agent-sdk/cli.js"));
 
-      authMethod._meta = {
-        "terminal-auth": {
-          command: cliPath,
-          args: ["/login"],
-          label: "Claude Code Login",
-        },
-      };
-    }
+    //   authMethod._meta = {
+    //     "terminal-auth": {
+    //       command: "node",
+    //       args: [cliPath, "/login"],
+    //       label: "Claude Code Login",
+    //     },
+    //   };
+    // }
 
     return {
       protocolVersion: 1,


### PR DESCRIPTION
This was causing issues on Windows in the current form, and also has some other issues that need looking into. Will revisit later.
