### PR TITLE
Adding load session

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ npm install @zed-industries/claude-code-acp
 
 You can then use `claude-code-acp` as a regular ACP agent:
 
-```
+```bash
 ANTHROPIC_API_KEY=sk-... claude-code-acp
 ```
 


### PR DESCRIPTION
Should fix https://github.com/zed-industries/claude-code-acp/issues/64
Followed the instructions here: https://agentclientprotocol.com/protocol/session-setup#loading-a-session
Added a very simplistic in-memory approach.

Is there any requirement to add for testing (integration, e2e, unit, etc.)?

Thanks for the great work on this!! Really appreciate it.