### PR TITLE
More forgiving unreachable

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -393,6 +393,7 @@ export class ClaudeAcpAgent implements Agent {
               break;
             default:
               unreachable(message);
+              break;
           }
           break;
         case "result": {
@@ -430,6 +431,7 @@ export class ClaudeAcpAgent implements Agent {
               return { stopReason: "max_turn_requests" };
             default:
               unreachable(message);
+              break;
           }
           break;
         }
@@ -514,6 +516,7 @@ export class ClaudeAcpAgent implements Agent {
           break;
         default:
           unreachable(message);
+          break;
       }
     }
     throw new Error("Session did not end in result");
@@ -1008,6 +1011,7 @@ export function toAcpNotifications(
 
       default:
         unreachable(chunk);
+        break;
     }
     if (update) {
       output.push({ sessionId, update });
@@ -1053,6 +1057,7 @@ export function streamEventToAcpNotifications(
 
     default:
       unreachable(event);
+      return [];
   }
 }
 

--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -582,7 +582,8 @@ In sessions with ${toolNames.killShell} always use it instead of KillShell.`,
               content: [{ type: "text", text: "Command killed by timeout." }],
             };
           default: {
-            return unreachable(bgTerm);
+            unreachable(bgTerm);
+            throw new Error("Unexpected background terminal status");
           }
         }
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,14 +75,14 @@ export function nodeToWebReadable(nodeStream: Readable): ReadableStream<Uint8Arr
   });
 }
 
-export function unreachable(value: never): never {
+export function unreachable(value: never) {
   let valueAsString;
   try {
     valueAsString = JSON.stringify(value);
   } catch {
     valueAsString = value;
   }
-  throw new Error(`Unexpected case: ${valueAsString}`);
+  console.error(`Unexpected case: ${valueAsString}`);
 }
 
 export function sleep(time: number): Promise<void> {


### PR DESCRIPTION
Currently, if we get an unexpected message, we crash. While this is fine in the world where we vendor CC (which we do by default) we also allow users to override the executable for cases where their work needs a wrapper.

This makes it so that we just log the event that we get, but don't crash right away in case we can continue on.
