### PR TITLE
Prevent invalid locations when Read tool call has no file_path

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -134,7 +134,14 @@ export function toolInfoFromToolUse(
         title: "Read File",
         kind: "read",
         content: [],
-        locations: [{ path: input.file_path, line: input.offset ?? 0 }],
+        locations: input.file_path
+          ? [
+              {
+                path: input.file_path,
+                line: input.offset ?? 0,
+              },
+            ]
+          : [],
       };
 
     case "LS":


### PR DESCRIPTION
## Summary

Follow-up to #121. The same issue (invalid locations when `file_path` is undefined) existed in the `Read` tool case as well.

## Problem

The ACP spec requires `path` as a required field in `ToolCallLocation`. PR #121 fixed this for `mcp__acp__Read`, but the same issue remained for the `Read` tool case.

When Claude generates a Read tool call without `file_path`, the current code produces an invalid notification:

```json
{
  "locations": [
    {
      "line": 0
    }
  ]
}
```

This causes the following error in the client:

```
Error handling notification
{code: -32602, message: 'Invalid params', data: {…}}
```

## Solution

Return an empty `locations` array when `input.file_path` is undefined, consistent with the fix in #121.