### PR TITLE
Allow to resume previous session

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -198,9 +198,9 @@ export class ClaudeAcpAgent implements Agent {
     }
 
     // Extract options from _meta if provided
-		const userProvidedOptions = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options
+    const userProvidedOptions = (params._meta as NewSessionMeta | undefined)?.claudeCode?.options;
 
-		const sessionId = userProvidedOptions?.resume || randomUUID()
+    const sessionId = userProvidedOptions?.resume || randomUUID();
     const input = new Pushable<SDKUserMessage>();
 
     const mcpServers: Record<string, McpServerConfig> = {};
@@ -253,11 +253,11 @@ export class ClaudeAcpAgent implements Agent {
 
     const permissionMode = "default";
 
-		const extraArgs = { ...userProvidedOptions?.extraArgs }
-		if (userProvidedOptions?.resume === undefined) {
-			// Set our own session id if not resuming an existing session.
-			extraArgs["session-id"] = sessionId
-		}
+    const extraArgs = { ...userProvidedOptions?.extraArgs };
+    if (userProvidedOptions?.resume === undefined) {
+      // Set our own session id if not resuming an existing session.
+      extraArgs["session-id"] = sessionId;
+    }
 
     const options: Options = {
       systemPrompt,


### PR DESCRIPTION
When the ACP client persists the session id to support resuming, it has no way to pass it back to the agent to resume an existing session as the current implementation always creates a new id that is now shared with Claude Code.

My client used to pass the value in the `--resume` within Claude Code option, but `--resume` is not compatible with the new `--session-id`:

```
--session-id cannot be used with --continue or --resume.
```

Change:

When `--resume` is used, extract its value and use it as the session id.