### PR TITLE
Fix Node.js v18 compatibility with JSON imports

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -54,8 +54,11 @@ import {
 } from "./tools.js";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
-import packageJson from "../package.json" with { type: "json" };
+import { createRequire } from "node:module";
 import { randomUUID } from "node:crypto";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json");
 
 export const CLAUDE_CONFIG_DIR = process.env.CLAUDE ?? path.join(os.homedir(), ".claude");
 


### PR DESCRIPTION
## Summary

Fixes #204

Replace JSON import assertions with `createRequire` to support Node.js v18.19.0 runtime used by Zed editor.

## Problem

The code was using `import packageJson from "../package.json" with { type: "json" }` syntax, which requires Node.js 20.10.0+. However, Zed bundles Node.js v18.19.0, causing a runtime error:

```
SyntaxError: Unexpected token 'with'
```

This issue was introduced when `@types/node` was updated to 25.0.0, which enforces the newer import attribute syntax that isn't supported by Node.js v18.

## Solution

Use `createRequire` from `node:module` to load the JSON file:

```typescript
import { createRequire } from "node:module";

const require = createRequire(import.meta.url);
const packageJson = require("../package.json");
```

This approach:
- ✅ Works with Node.js v18.19.0
- ✅ Satisfies TypeScript with @types/node 25.0.0
- ✅ Maintains ES module compatibility

## Test Plan

- [x] TypeScript compilation passes (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [ ] Tested in Zed editor with Node.js v18.19.0