### PR TITLE
Fix double tool call notifications

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1177,15 +1177,8 @@ export function streamEventToAcpNotifications(
   const event = message.event;
   switch (event.type) {
     case "content_block_start":
-      return toAcpNotifications(
-        [event.content_block],
-        "assistant",
-        sessionId,
-        toolUseCache,
-        fileContentCache,
-        client,
-        logger,
-      );
+      // Ignore, there is no content in `content_block_start`.
+      return [];
     case "content_block_delta":
       return toAcpNotifications(
         [event.delta],


### PR DESCRIPTION
I think we only want to handle partial content for text / thinking.

Atm, the `stream_event` messages received from CC for a tool call input look like:

```
{
  "type": "content_block_start",
  "index": 2,
  "content_block": {
    "type": "tool_use",
    "id": "toolu_01Fg5xTnmKtJLdmAwmvc9C7Y",
    "name": "Glob",
    "input": {}
  }
}
{
  "type": "content_block_delta",
  "index": 2,
  "delta": {
    "type": "input_json_delta",
    "partial_json": ""
  }
}
{
  "type": "content_block_delta",
  "index": 2,
  "delta": {
    "type": "input_json_delta",
    "partial_json": "{\"pattern\":"
  }
}
{
  "type": "content_block_delta",
  "index": 2,
  "delta": {
    "type": "input_json_delta",
    "partial_json": " \"**/readme"
  }
}
{
  "type": "content_block_delta",
  "index": 2,
  "delta": {
    "type": "input_json_delta",
    "partial_json": ".md\"}"
  }
}
{
  "type": "content_block_stop",
  "index": 2
}
```
We also receive a message from the assistant with the consolidated tool call.

The first message (`content_block_start`) is processed and ACP sends a notification for a `tool_call` with no input data. The delta messages are ignored as we ignore `input_json_delta`.
Then when CC sends the consolidated assistant message, ACP sends another `tool_call` notification, this time with input data, for the same tool call.

This change remove all processing for `content_block_start` as I don't think this is ever useful. Events for which we want to handle partial content (`text_delta` / `thinking_delta`) will be processed through the `content_block_delta`. I could not see a reason to a send a notification with an empty text / thinking content.

If the initial empty notification is needed for text/thinking delta, we could alternatively ensure that we're only processing `content_block_start` for those types.