### PR TITLE
Add ACP session/load support (replay Claude Code history)

### DIFF
--- a/src/tests/load-session.test.ts
+++ b/src/tests/load-session.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { ClaudeAcpAgent } from "../acp-agent.js";
+
+describe("loadSession capability", () => {
+  it("advertises loadSession in initialize response", async () => {
+    const agent = new ClaudeAcpAgent({} as any);
+    const result = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {},
+    });
+
+    expect(result.agentCapabilities?.loadSession).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
Implements ACP `session/load` (SDK `loadSession`) for `claude-code-acp`, allowing clients to load an existing Claude Code session and receive the full conversation replay via `session/update` notifications.

This unblocks tools like AgentBoss that rely on ACP `session/load` to reopen a saved chat and rehydrate transcript/tool state.

## Problem
- The adapter previously did **not** implement `session/load`, so clients received JSON-RPC `-32601` (method not found).
- The adapter also did not advertise `loadSession`, preventing clients from attempting history replay.

## What changed
- `initialize()` now advertises `agentCapabilities.loadSession: true`.
- Added `loadSession(params)` implementation:
  - Ensures the requested `sessionId` exists in-process (creates/resumes via the Claude Agent SDK if needed).
  - Locates the Claude Code transcript under `~/.claude/projects/**/<sessionId>.jsonl` (respects `CLAUDE` env via `CLAUDE_CONFIG_DIR`).
  - Streams the JSONL transcript and replays user/assistant messages as ACP `session/update` notifications (via existing `toAcpNotifications(...)`).
  - Returns `{}` as the load response (per ACP schema).

## Implementation notes
- Transcript lookup prefers the direct project path derived from `params.cwd` (Claude Code encodes cwd segments with `-`):
  - `~/.claude/projects/<encoded-cwd>/<sessionId>.jsonl`
- Falls back to scanning `~/.claude/projects/*/<sessionId>.jsonl` when the direct path is not found.
- Replays only `type: "user" | "assistant"` records (best-effort); other record types are ignored.

## Testing
- `npm run test:run`
- Added unit test: `src/tests/load-session.test.ts` (asserts `loadSession` is advertised).

## How to try it
From any ACP client:
1. Call `initialize` and confirm `loadSession: true`.
2. Call `session/load` with a Claude Code `sessionId` that exists under `~/.claude/projects/**/`.
3. Consume `session/update` notifications to reconstruct the conversation history.
