### PR TITLE
filter invalid hints

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -871,7 +871,10 @@ async function getAvailableSlashCommands(query: Query): Promise<AvailableCommand
 
   return commands
     .map((command) => {
-      const input = command.argumentHint ? { hint: command.argumentHint } : null;
+      const input =
+        command.argumentHint && typeof command.argumentHint === "string"
+          ? { hint: command.argumentHint }
+          : null;
       let name = command.name;
       if (command.name.endsWith(" (MCP)")) {
         name = `mcp:${name.replace(" (MCP)", "")}`;


### PR DESCRIPTION
Apparently, the SDK started to return hints as array for skills, despite the documentation saying it should be a string:

https://platform.claude.com/docs/en/agent-sdk/typescript#slash-command

This makes the ACP SDK fail to parse the availableCommands:

```json
{
  "code": "invalid_union",
  "errors": [
    [
      {
        "expected": "string",
        "code": "invalid_type",
        "path": [
          "hint"
        ],
        "message": "Invalid input: expected string, received array"
      }
    ],
    [
      {
        "expected": "null",
        "code": "invalid_type",
        "path": [],
        "message": "Invalid input: expected null, received object"
      }
    ]
  ],
  "path": [
    "availableCommands",
    4,
    "input"
  ],
  "message": "Invalid input"
},
```

<img width="804" height="178" alt="image" src="https://github.com/user-attachments/assets/657bfa73-4467-4cfe-910e-09b1d58c3268" />

For now, I decided to just not provide the hint, as Anthropic should probably fix this, but we could also try to get the value from the array if there's one:

```json
{
    "description": "View or manage comments on an issue (plugin:beads@beads-marketplace)",
    "input": {
        "hint": [
            "issue-id"
        ]
    },
    "name": "beads:comments"
},
```