### PR TITLE
Disable AskUserQuestion for now

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -717,7 +717,8 @@ export class ClaudeAcpAgent implements Agent {
     };
 
     const allowedTools = [];
-    const disallowedTools = [];
+    // Disable this for now, not a great way to expose this over ACP at the moment (in progress work so we can revisit)
+    const disallowedTools = ["AskUserQuestion"];
 
     // Check if built-in tools should be disabled
     const disableBuiltInTools = params._meta?.disableBuiltInTools === true;


### PR DESCRIPTION
This is a cool tool. But we don't have a great way to express it over ACP at the moment.

Using RequestPermission _kind of_ works. But it conflates question asking with a very security focused flow, which has problems as well.

Rather than have strange tool output, we'll just turn it off for now.
