### PR TITLE
Fix glob matching for file permissions on Windows

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -128,7 +128,8 @@ function normalizePath(filePath: string, cwd: string): string {
   } else if (!path.isAbsolute(filePath)) {
     filePath = path.join(cwd, filePath);
   }
-  return path.normalize(filePath);
+  // Convert backslashes to forward slashes for minimatch compatibility on Windows
+  return path.normalize(filePath).replace(/\\/g, "/");
 }
 
 /**


### PR DESCRIPTION
8 tests in settings.test.ts fail on Windows because `minimatch` expects forward slashes but `path.normalize()` returns backslashes.

Converts paths to forward slashes before matching.