### PR TITLE
fix: return content from Write tool

### DIFF
--- a/src/mcp-server.ts
+++ b/src/mcp-server.ts
@@ -272,7 +272,7 @@ Usage:
             content: [
               {
                 type: "text",
-                text: `Wrote file: ${input.file_path}`,
+                text: `The file ${input.file_path} has been updated successfully.`,
               },
             ],
           };


### PR DESCRIPTION
## Problem
The Write tool was returning an empty content array, which causes errors with some AI providers when using Claude Code through ACP.

Specifically, Z.AI GLM-4.7 returns error 1213 "The prompt parameter was not received normally" when the Write tool returns empty content.
This error causes the API request to fail and halts the conversation flow, even though the file write itself succeeds.

Note: The Claude Code CLI works fine - this issue is specific to the ACP integration.

## Solution
Return a confirmation message from the Write tool, aligning it with Read, Edit, and Bash tools which all return content.

## Changes
- Write tool now returns `content: [{type: "text", text: "Wrote file: ${input.file_path}"}]`

This change only adds a confirmation message - no existing functionality is modified.

## Testing
Tested with Zed editor. Would appreciate others verifying it works as expected.

Relates to zed-industries/zed#45704
