### PR TITLE
fix: permission rules should not match tools without argument accessors

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -168,7 +168,9 @@ function matchesRule(rule: ParsedRule, toolName: string, toolInput: unknown, cwd
 
   const argAccessor = TOOL_ARG_ACCESSORS[toolName];
   if (!argAccessor) {
-    return true;
+    // If we cannot extract the argument for this tool, the rule does not apply
+    // (e.g., ZedEditorContext should not match Bash deny rules)
+    return false;
   }
 
   const actualArg = argAccessor(toolInput);


### PR DESCRIPTION
## Problem

When checking if a permission rule (like `Bash(rm -rf:*)`) matches a tool invocation, the `matchesRule` function returns `true` if no argument accessor is defined for that tool. This causes deny rules to incorrectly block unrelated MCP tools.

**Reproduction:**
1. Add a custom MCP tool (e.g., `ZedEditorContext`) that doesn't have an entry in `TOOL_ARG_ACCESSORS`
2. Have a deny rule like `Bash(rm -rf:*)` in settings
3. Try to use the custom tool → blocked with "Denied by settings rule: Bash(rm -rf:*)"

## Root Cause

In `settings.ts`, the `matchesRule` function:

```typescript
const argAccessor = TOOL_ARG_ACCESSORS[toolName];
if (!argAccessor) {
  return true;  // BUG: should be false
}
```

The logic was: "if we can't check the argument, assume it matches." But the correct logic should be: "if we can't check the argument, the rule doesn't apply to this tool."

## Fix

Changed `return true` to `return false` — if we can't extract an argument to check against the rule's pattern, the rule simply doesn't apply.

## Testing

- Verified custom MCP tools are no longer blocked by unrelated Bash deny rules
- Existing permission tests still pass