### PR TITLE
fix: respect user model preference from settings.json

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -28,6 +28,7 @@ export interface PermissionSettings {
 export interface ClaudeCodeSettings {
   permissions?: PermissionSettings;
   env?: Record<string, string>;
+  model?: string;
 }
 
 export type PermissionDecision = "allow" | "deny" | "ask";
@@ -368,6 +369,10 @@ export class SettingsManager {
 
       if (settings.env) {
         merged.env = { ...merged.env, ...settings.env };
+      }
+
+      if (settings.model) {
+        merged.model = settings.model;
       }
     }
 

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -465,6 +465,41 @@ describe("SettingsManager", () => {
       });
       expect(envResult.decision).toBe("deny");
     });
+
+    it("should merge model setting with later sources taking precedence", async () => {
+      const claudeDir = path.join(tempDir, ".claude");
+      await fs.promises.mkdir(claudeDir, { recursive: true });
+
+      // Project settings with one model
+      await fs.promises.writeFile(
+        path.join(claudeDir, "settings.json"),
+        JSON.stringify({
+          model: "claude-3-5-sonnet",
+        }),
+      );
+
+      settingsManager = new SettingsManager(tempDir);
+      await settingsManager.initialize();
+
+      let settings = settingsManager.getSettings();
+      expect(settings.model).toBe("claude-3-5-sonnet");
+
+      // Add local settings that override the model
+      await fs.promises.writeFile(
+        path.join(claudeDir, "settings.local.json"),
+        JSON.stringify({
+          model: "claude-3-5-haiku",
+        }),
+      );
+
+      // Re-initialize to pick up local settings
+      settingsManager.dispose();
+      settingsManager = new SettingsManager(tempDir);
+      await settingsManager.initialize();
+
+      settings = settingsManager.getSettings();
+      expect(settings.model).toBe("claude-3-5-haiku");
+    });
   });
 
   describe("ask rules", () => {


### PR DESCRIPTION
- Integrates model into existing settings infrastructure
- Respects precedence: user < project < local < enterprise
- Removes duplicate file reading logic

Fixes #225