### PR TITLE
allow using /context command

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -350,6 +350,21 @@ export class ClaudeAcpAgent implements Agent {
             typeof message.message.content === "string" &&
             message.message.content.includes("<local-command-stdout>")
           ) {
+            // Handle /context by sending its reply as regular agent message.
+            if (message.message.content.includes("Context Usage")) {
+              for (const notification of toAcpNotifications(
+                message.message.content
+                  .replace("<local-command-stdout>", "")
+                  .replace("</local-command-stdout>", ""),
+                "assistant",
+                params.sessionId,
+                this.toolUseCache,
+                this.client,
+                this.logger,
+              )) {
+                await this.client.sessionUpdate(notification);
+              }
+            }
             this.logger.log(message.message.content);
             break;
           }
@@ -872,7 +887,6 @@ async function getAvailableModels(query: Query): Promise<SessionModelState> {
 
 async function getAvailableSlashCommands(query: Query): Promise<AvailableCommand[]> {
   const UNSUPPORTED_COMMANDS = [
-    "context",
     "cost",
     "login",
     "logout",


### PR DESCRIPTION
I experimented with https://agentclientprotocol.com/rfds/session-usage (see https://github.com/agentclientprotocol/agent-client-protocol/pull/415), but the Claude Agent SDK does not seem to return the information we need for an accurate context indicator. For example, one request to explore a project returned 500k+ cached read tokens in Claude's `result` message, while the agent reported 64k tokens used. I can open a PR with those changes for reference once the Typescript SDK is updated.

To allow users to still see the current context usage, allowing to run `/context` seems to be the second best option. This PR changes the code to handle the `<local-command-stdout>` message that the SDK generates when sending `/context` and includes `/context` as allowed command.

Screenshot from Tidewave with this change:

<img width="460" height="1079" alt="image" src="https://github.com/user-attachments/assets/a3796e46-4014-4988-a993-e13d38d38d96" />
