### PR TITLE
Do not list keybindings-help as a command

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1104,6 +1104,7 @@ async function getAvailableModels(
 async function getAvailableSlashCommands(query: Query): Promise<AvailableCommand[]> {
   const UNSUPPORTED_COMMANDS = [
     "cost",
+    "keybindings-help",
     "login",
     "logout",
     "output-style:new",


### PR DESCRIPTION
This is actually a skill that comes as part of Claude Code,
which shouldn't be exposed as a command over ACP.