### PR TITLE
fix: Bash permission rules should only match Bash tool calls

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -156,7 +156,7 @@ function matchesRule(rule: ParsedRule, toolName: string, toolInput: unknown, cwd
   // - "Claude will make a best-effort attempt to apply Read rules to all built-in tools
   //    that read files like Grep, Glob, and LS."
   const ruleAppliesToTool =
-    rule.toolName === "Bash" ||
+    (rule.toolName === "Bash" && toolName === acpToolNames.bash) ||
     (rule.toolName === "Edit" && FILE_EDITING_TOOLS.includes(toolName)) ||
     (rule.toolName === "Read" && FILE_READING_TOOLS.includes(toolName));
 


### PR DESCRIPTION
## Summary
Fixes a bug where `Bash(...)` permission rules would incorrectly match against non-Bash tools like Edit and Write.

## The Bug
In `matchesRule`, this check was the problem:

```typescript
const ruleAppliesToTool =
  rule.toolName === "Bash" ||  // <-- Only checks the RULE type, not the TOOL type
  (rule.toolName === "Edit" && FILE_EDITING_TOOLS.includes(toolName)) ||
  (rule.toolName === "Read" && FILE_READING_TOOLS.includes(toolName));
```

Notice that Edit and Read rules correctly check BOTH the rule type AND the tool type, but Bash only checked the rule type. This meant `rule.toolName === "Bash"` returned true for ANY tool when the rule was a Bash rule.

When a non-Bash tool (like `mcp__acp__Edit`) was invoked:
1. `rule.toolName === "Bash"` → `true`, so `ruleAppliesToTool = true`
2. The Bash-specific command matching was skipped (since `toolName !== acpToolNames.bash`)
3. Code fell through to the glob matching at the end of `matchesRule`
4. The rule's argument was matched as a file glob against the file being edited

## Evidence
With settings containing `Bash(./inbox:*)`, editing a file showed:

```
[PreToolUseHook] Tool: mcp__acp__Edit, Decision: allow, Rule: Bash(./inbox:*)
```

The Edit tool was being allowed by a Bash rule.

## The Fix
Add a check to ensure Bash rules only apply when the tool is actually Bash:

```typescript
// Before (buggy)
rule.toolName === "Bash" ||

// After (fixed)  
(rule.toolName === "Bash" && toolName === acpToolNames.bash) ||
```

This makes the Bash check consistent with how Edit and Read rules work.

## Test plan
- [x] Verify `Bash(./script:*)` allows `mcp__acp__Bash` with command `./script foo`
- [x] Verify `Bash(./script:*)` does NOT allow `mcp__acp__Edit` on file `./script`

🤖 Generated with [Claude Code](https://claude.ai/code)