### PR TITLE
Upgrade claude-agent-sdk to 0.2.32

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.13.1",
-        "@anthropic-ai/claude-agent-sdk": "0.2.29",
+        "@anthropic-ai/claude-agent-sdk": "^0.2.32",
         "@modelcontextprotocol/sdk": "1.26.0",
         "diff": "8.0.3",
         "minimatch": "10.1.1"
@@ -42,9 +42,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.29",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.29.tgz",
-      "integrity": "sha512-b+655n4ZqqAiMQEL3P44e9UurkI7WWanWTQQQTEcKngL5YCjjXExEPEJRxrmqp8mQXs0kLErZhObx0ZuwibOhA==",
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.32.tgz",
+      "integrity": "sha512-8AtsSx/M9jxd0ihS08eqa7VireTEuwQy0i1+6ZJX93LECT6Svlf47dPJiAm7JB+BhVMmwTfQeS6x1akIcCfvbQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agentclientprotocol/sdk": "0.13.1",
-    "@anthropic-ai/claude-agent-sdk": "0.2.29",
+    "@anthropic-ai/claude-agent-sdk": "^0.2.32",
     "@modelcontextprotocol/sdk": "1.26.0",
     "diff": "8.0.3",
     "minimatch": "10.1.1"


### PR DESCRIPTION
Adds support for Opus 4.6 and the new 1M context Opus model.