### PR TITLE
Use fixed version for claude-agent-sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agentclientprotocol/sdk": "0.13.1",
-    "@anthropic-ai/claude-agent-sdk": "^0.2.32",
+    "@anthropic-ai/claude-agent-sdk": "0.2.32",
     "@modelcontextprotocol/sdk": "1.26.0",
     "diff": "8.0.3",
     "minimatch": "10.1.1"


### PR DESCRIPTION
Removes caret prefix to pin the exact SDK version.