### PR TITLE
fix: merge user-provided disallowedTools instead of overwriting

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1105,8 +1105,8 @@ export class ClaudeAcpAgent implements Agent {
     if (allowedTools.length > 0) {
       options.allowedTools = allowedTools;
     }
-    if (disallowedTools.length > 0 || (userProvidedOptions?.disallowedTools?.length ?? 0) > 0) {
-      options.disallowedTools = [...(userProvidedOptions?.disallowedTools || []), ...disallowedTools];
+    if (disallowedTools.length > 0) {
+      options.disallowedTools = [...(options.disallowedTools || []), ...disallowedTools];
     }
 
     // Handle abort controller from meta options


### PR DESCRIPTION
## Summary

- User-provided `disallowedTools` from `_meta.claudeCode.options` were silently overwritten by ACP's internal list
- Now merges both lists, following the same pattern used for `hooks` and `mcpServers`
- Updated `NewSessionMeta` JSDoc to document the merge behavior

Fixes #294