### PR TITLE
fix: Replace all non-alphanumeric characters in encodeProjectPath

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -172,15 +172,7 @@ export function extractLinesWithByteLimit(
 
 // Helper to encode a path like Claude does:
 // - Unix: "/Users/test" -> "-Users-test"
-// - Windows: "C:\Users\test" -> "C-Users-test"
+// - Windows: "C:\Users\test" -> "C--Users-test"
 export function encodeProjectPath(cwd: string): string {
-  const windowsPathMatch = cwd.match(/^([A-Za-z]):[\\/]/);
-  if (windowsPathMatch) {
-    const driveLetter = windowsPathMatch[1];
-    const rest = cwd.slice(2);
-    return `${driveLetter}${rest.replace(/[\\/]/g, "-")}`;
-  }
-
-  // Unix paths
-  return cwd.replace(/\//g, "-");
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
 }


### PR DESCRIPTION
This PR fixes `encodeProjectPath` to replace all non-alphanumeric characters with `-`, matching how Claude Code actually encodes project paths.

The previous implementation only replaced path separators (`/` on Unix, `\` on Windows), so characters like `_`, non-ASCII characters (e.g. CJK), and other non-alphanumeric characters were left as-is. This caused a mismatch with the paths encoded by Claude Code, resulting in session lookups failing with "Session not found" for directories containing such characters.

The fix also removes the Windows-specific code path, as the simple regex `[^a-zA-Z0-9]` correctly handles all platforms.

Related to #300
