### PR TITLE
don't include /login slash command in login command

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -218,7 +218,7 @@ export class ClaudeAcpAgent implements Agent {
       authMethod._meta = {
         "terminal-auth": {
           command: "node",
-          args: [cliPath, "/login"],
+          args: [cliPath],
           label: "Claude Code Login",
         },
       };


### PR DESCRIPTION
Claude resubmits the slash command after authenticating, so it will ask for authentication twice.
Since Claude Code prompts for setup and authentication anyway if not signed in, we can just not include /login in the command.