### PR TITLE
fix: convert Read tool image content to ACP format (#322)

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -491,7 +491,7 @@ export function toolUpdateFromToolResult(
                     type: "text",
                     text: markdownEscape(content.text.replace(SYSTEM_REMINDER, "")),
                   }
-                : content,
+                : toAcpContentBlock(content, false),
           })),
         };
       } else if (typeof toolResult.content === "string" && toolResult.content.length > 0) {


### PR DESCRIPTION
When the Read tool returns image content (e.g., reading a .png file), the raw Claude SDK image block was passed through unconverted, causing ACP clients to fail deserializing the tool call completion event. Route non-text content through `toAcpContentBlock` to produce the correct ACP image format.