### PR TITLE
ACP Session Usage

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -705,7 +705,7 @@ export class ClaudeAcpAgent implements Agent {
           }
 
           // Build the usage response
-          const buildUsageResponse = (): PromptResponse["usage"] => ({
+          const usage: PromptResponse["usage"] = {
             inputTokens: session.accumulatedUsage.inputTokens,
             outputTokens: session.accumulatedUsage.outputTokens,
             cachedReadTokens: session.accumulatedUsage.cachedReadTokens,
@@ -715,7 +715,7 @@ export class ClaudeAcpAgent implements Agent {
               session.accumulatedUsage.outputTokens +
               session.accumulatedUsage.cachedReadTokens +
               session.accumulatedUsage.cachedWriteTokens,
-          });
+          };
 
           switch (message.subtype) {
             case "success": {
@@ -725,7 +725,7 @@ export class ClaudeAcpAgent implements Agent {
               if (message.is_error) {
                 throw RequestError.internalError(undefined, message.result);
               }
-              return { stopReason: "end_turn", usage: buildUsageResponse() };
+              return { stopReason: "end_turn", usage };
             }
             case "error_during_execution":
               if (message.is_error) {
@@ -734,7 +734,7 @@ export class ClaudeAcpAgent implements Agent {
                   message.errors.join(", ") || message.subtype,
                 );
               }
-              return { stopReason: "end_turn", usage: buildUsageResponse() };
+              return { stopReason: "end_turn", usage };
             case "error_max_budget_usd":
             case "error_max_turns":
             case "error_max_structured_output_retries":
@@ -744,7 +744,7 @@ export class ClaudeAcpAgent implements Agent {
                   message.errors.join(", ") || message.subtype,
                 );
               }
-              return { stopReason: "max_turn_requests", usage: buildUsageResponse() };
+              return { stopReason: "max_turn_requests", usage };
             default:
               unreachable(message, this.logger);
               break;


### PR DESCRIPTION
The AI in https://github.com/zed-industries/claude-agent-acp/pull/344 had one good idea: only use the usage from the last assistant message for context size. Of course, `usage` on the AssistantMessage is not documented in the Agent SDK (we need to do an ugly cast), but this seems to work alright.

We don't get the exact new usage after compaction, so I set it to zero.