### PR TITLE
Authentication adjustments for JB integration

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -310,7 +310,8 @@ export class ClaudeAcpAgent implements Agent {
     };
 
     // If client supports terminal-auth capability, use that instead.
-    if (request.clientCapabilities?._meta?.["terminal-auth"] === true) {
+    const supportsTerminalAuth = request.clientCapabilities?._meta?.["terminal-auth"] === true;
+    if (supportsTerminalAuth) {
       let command: string;
       let args: string[];
 
@@ -361,7 +362,8 @@ export class ClaudeAcpAgent implements Agent {
         version: packageJson.version,
       },
       authMethods: [
-        ...(shouldHideClaudeAuth() ? [] : [authMethod]),
+        // Terminal auth can also be used for API keys, so don't gate it on --hide-claude-auth.
+        ...(shouldHideClaudeAuth() && !supportsTerminalAuth ? [] : [authMethod]),
         ...(supportsGatewayAuth ? [gatewayAuthMethod] : []),
       ],
     };

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -112,7 +112,7 @@ describe("authorization", () => {
     );
   });
 
-  it("hide claude authentication", async () => {
+  it("hide claude authentication without terminal-auth", async () => {
     const [agent] = await createAgentMock();
     vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
 
@@ -127,6 +127,21 @@ describe("authorization", () => {
     );
     expect(initializeResponse.authMethods).toContainEqual(
       expect.objectContaining({ id: "gateway" }),
+    );
+  });
+
+  it("terminal auth still offered when --hide-claude-auth is set", async () => {
+    const [agent] = await createAgentMock();
+    vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
+
+    const initializeResponse = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        _meta: { "terminal-auth": true },
+      },
+    });
+    expect(initializeResponse.authMethods).toContainEqual(
+      expect.objectContaining({ id: "claude-login" }),
     );
   });
 


### PR DESCRIPTION
Updated authentication methods for IDEA compatibility and SDK compliance

#### New authentication type: gateway (url + custom headers)
 
- Required to support native IDEA authentication flows
 
#### Process argument to hide Claude Code authentication

- Ensures compliance with Anthropic’s third-party authentication policies.

https://platform.claude.com/docs/en/agent-sdk/overview

> Unless previously approved, Anthropic does not allow third party developers to offer claude.ai login or rate limits for their products, including agents built on the Claude Agent SDK. Please use the API key authentication methods described in this document instead.