### PR TITLE
fix: throw resourceNotFound when loadSession fails to resume

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -370,28 +370,16 @@ export class ClaudeAcpAgent implements Agent {
   }
 
   async loadSession(params: LoadSessionRequest): Promise<LoadSessionResponse> {
-    let response;
-    try {
-      response = await this.createSession(
-        {
-          cwd: params.cwd,
-          mcpServers: params.mcpServers ?? [],
-          _meta: params._meta,
-        },
-        {
-          resume: params.sessionId,
-        },
-      );
-    } catch (error) {
-      // When resuming a session that has no persisted data on disk (e.g. the
-      // CLI subprocess from session/new exited before writing a .jsonl file),
-      // the subprocess dies immediately and createSession rejects with a
-      // generic -32603 "Query closed before response received" error.
-      //
-      // Re-throw as resourceNotFound (-32002) so callers can fall back to
-      // session/new instead of treating it as an unrecoverable failure.
-      throw RequestError.resourceNotFound(params.sessionId);
-    }
+    const response = await this.createSession(
+      {
+        cwd: params.cwd,
+        mcpServers: params.mcpServers ?? [],
+        _meta: params._meta,
+      },
+      {
+        resume: params.sessionId,
+      },
+    );
 
     await this.replaySessionHistory(params.sessionId);
 
@@ -1220,7 +1208,19 @@ export class ClaudeAcpAgent implements Agent {
       nextPendingOrder: 0,
     };
 
-    const initializationResult = await q.initializationResult();
+    let initializationResult;
+    try {
+      initializationResult = await q.initializationResult();
+    } catch (error) {
+      if (
+        creationOpts.resume &&
+        error instanceof Error &&
+        error.message === "Query closed before response received"
+      ) {
+        throw RequestError.resourceNotFound(sessionId);
+      }
+      throw error;
+    }
 
     const models = await getAvailableModels(q, initializationResult.models, settingsManager);
 


### PR DESCRIPTION
## Summary

- When `loadSession` calls `createSession({ resume: sessionId })` and the CLI subprocess can't find persisted session data (no `.jsonl` file), the subprocess exits immediately and `createSession` rejects with a generic `-32603` ("Query closed before response received")
- ACP clients like [acpx](https://github.com/openclaw/acpx) check for `-32001`/`-32002` (resource not found) to fall back to `session/new` — the generic `-32603` bypasses this, causing the turn to fail entirely
- This commonly happens when `session/new` creates an ACP session but the subprocess exits before writing session data (no prompt to process), then `session/prompt` tries `session/load` to resume a session that was never persisted

## Fix

Wrap the `createSession({ resume })` call in `loadSession()` with try/catch and re-throw as `RequestError.resourceNotFound()` (code `-32002`). This lets callers handle it with their existing fallback logic.

## Verification

Confirmed working in production with the [OpenClaw](https://github.com/openclaw/openclaw) gateway + acpx integration. Before the fix, all ACP tasks failed silently. After patching both this code path and acpx's `shouldFallbackToNewSession()` ([openclaw/acpx#30](https://github.com/openclaw/acpx/pull/30)), sessions fall back to `session/new` correctly.

Fixes #338
Closes #361
Closes #362