### PR TITLE
Surface better error message when Claude Code process exits unexpectedly

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -145,7 +145,6 @@ type Session = {
   query: Query;
   input: Pushable<SDKUserMessage>;
   cancelled: boolean;
-  healthy: boolean;
   permissionMode: PermissionMode;
   settingsManager: SettingsManager;
   accumulatedUsage: AccumulatedUsage;
@@ -422,15 +421,6 @@ export class ClaudeAcpAgent implements Agent {
     const session = this.sessions[params.sessionId];
     if (!session) {
       throw new Error("Session not found");
-    }
-
-    if (!session.healthy) {
-      session.input.end();
-      delete this.sessions[params.sessionId];
-      throw RequestError.internalError(
-        undefined,
-        "The Claude Code process has exited. Please start a new session.",
-      );
     }
 
     session.cancelled = false;
@@ -725,13 +715,12 @@ export class ClaudeAcpAgent implements Agent {
         message.includes("process terminated by signal") ||
         message.includes("Failed to write to process stdin")
       ) {
-        this.logger.error(`Session ${params.sessionId}: Claude Code process died: ${message}`);
-        session.healthy = false;
+        this.logger.error(`Session ${params.sessionId}: Claude Agent process died: ${message}`);
         session.input.end();
         delete this.sessions[params.sessionId];
         throw RequestError.internalError(
           undefined,
-          "The Claude Code process exited unexpectedly. Please start a new session.",
+          "The Claude Agent process exited unexpectedly. Please start a new session.",
         );
       }
       throw error;
@@ -764,11 +753,6 @@ export class ClaudeAcpAgent implements Agent {
       pending.resolve(true);
     }
     session.pendingMessages.clear();
-    if (!session.healthy) {
-      session.input.end();
-      delete this.sessions[params.sessionId];
-      return;
-    }
     await session.query.interrupt();
   }
 
@@ -1231,7 +1215,6 @@ export class ClaudeAcpAgent implements Agent {
       query: q,
       input: input,
       cancelled: false,
-      healthy: true,
       permissionMode,
       settingsManager,
       accumulatedUsage: {


### PR DESCRIPTION
As seen in https://github.com/zed-industries/zed/issues/39563, Claude Agent child processes can die mid-session (crash, signal, OOM, et al). When that happens, the SDK throws errors with internal messages like `"ProcessTransport closed"`, `"Failed to write to process stdin"`, or `"process terminated by signal"`. These would bubble up to the user as-is, which is not helpful.

At this point, it’s [not possible to continue the session](https://github.com/zed-industries/zed/issues/39563#issuecomment-3776814727) either (which I also confirmed myself), but that is not obvious from the error the user sees (screenshot on the left).

In my testing, I could not get the `Error: ProcessTransport is not ready for writing` error, but you can easily trigger the `SIGTERM` (exit code 143) by simply killing the `claude` child process spawned by the ACP adapter while the agent is streaming a response:

<img width="1621" height="54" alt="image" src="https://github.com/user-attachments/assets/29d989f1-7e56-44b3-992d-065218444958" />

In this case, you’d do `kill 74573` to trigger the error.

AFAICT, the child process is managed internally by the Claude Agent SDK (inside the `query` object returned by `query()`). The ACP agent only sees it as an `AsyncGenerator`. There’s no `process.pid` or `ChildProcess` handle exposed to check liveness against. The only way to discover the process is dead is when the SDK throws one of these transport-level errors*.

\*I got these error strings by asking Opus 4.6 to de-obfuscate (`node_modules/@anthropic-ai/claude-agent-sdk/sdk.mjs`)

| Before | After |
|--------|--------|
| <img width="466" height="62" alt="image" src="https://github.com/user-attachments/assets/dc959924-0929-4587-9ddd-4a3873f1fa5d" /> | <img width="462" height="77" alt="image" src="https://github.com/user-attachments/assets/77eff880-28da-489a-b9e3-e9f93abf3c7f" /> |

In other words, I think the best we (the ACP adapter) can do here is to grep for these transport errors and surface a _better_ error message to the user, as seen above.