### PR TITLE
fix: handle renamed Agent tool in toolInfoFromToolUse

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -110,6 +110,7 @@ export function toolInfoFromToolUse(
   const name = toolUse.name;
 
   switch (name) {
+    case "Agent":
     case "Task": {
       const input = toolUse.input as AgentInput | BashInput;
       return {


### PR DESCRIPTION
## Summary
- The Claude SDK renamed the `Task` tool to `Agent`, but `toolInfoFromToolUse` only matched `case "Task":`, so the `Agent` tool fell through to the `default` case — rendering as a bare "Agent" label with no description or content in the chat UI.
- Adds `case "Agent":` as a fallthrough before `case "Task":` so both names are handled identically.

## Test plan
- [ ] Verify that when Claude spawns a subagent, the tool call in Zed's chat shows the agent's description as the title (not a bare "Agent" label)