### PR TITLE
skip user replay

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -695,6 +695,10 @@ export class ClaudeAcpAgent implements Agent {
                 // the loop of the next prompt continues running
                 return { stopReason: "end_turn" };
               }
+              if ("isReplay" in message && message.isReplay) {
+                // not pending or unrelated replay message
+                break;
+              }
             }
 
             // Store latest assistant usage (excluding subagents)


### PR DESCRIPTION
Closes #381.
Relates to #348.

In #348 I added replay to handle queued prompts.
In Tidewave, we ignore user_message_chunks, so I did not experience the issue when testing. But clients that show the user_message_chunk like Zed showed the replayed content. This commit ensures that replayed messages are skipped.