### PR TITLE
Move `clientCapability.auth._meta.gateway` to `clientCapability._meta.gateway`.

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -154,18 +154,6 @@ export type NewSessionMeta = {
 };
 
 /**
- * Extended ClientCapabilities with `auth` field.
- * TODO: Remove once `auth` is added to the ACP SDK schema.
- */
-type ClientCapabilitiesWithAuth = ClientCapabilities & {
-  auth?: {
-    _meta?: {
-      gateway?: boolean;
-    };
-  };
-};
-
-/**
  * Extra metadata for 'gateway' authentication requests.
  */
 type GatewayAuthMeta = {
@@ -294,9 +282,8 @@ export class ClaudeAcpAgent implements Agent {
     };
 
     // Bypasses standard auth by routing requests through a custom Anthropic-protocol gateway.
-    // Only offered when the client advertises `auth._meta.gateway` capability.
-    const clientCaps = request.clientCapabilities as ClientCapabilitiesWithAuth | undefined;
-    const supportsGatewayAuth = clientCaps?.auth?._meta?.gateway === true;
+    // Only offered when the client advertises `_meta.gateway` capability.
+    const supportsGatewayAuth = request.clientCapabilities?._meta?.gateway === true;
 
     const gatewayAuthMethod: AuthMethod = {
       id: "gateway",

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -58,7 +58,7 @@ describe("authorization", () => {
     const initializeResponse = await agent.initialize({
       protocolVersion: 1,
       clientCapabilities: {
-        auth: { _meta: { gateway: true } },
+        _meta: { gateway: true },
       } as any,
     });
     expect(initializeResponse.authMethods).toContainEqual(
@@ -72,7 +72,7 @@ describe("authorization", () => {
     const initializeResponse = await agent.initialize({
       protocolVersion: 1,
       clientCapabilities: {
-        auth: { _meta: { gateway: true } },
+        _meta: { gateway: true },
       } as any,
     });
     expect(initializeResponse.authMethods).toContainEqual(
@@ -119,7 +119,7 @@ describe("authorization", () => {
     const initializeResponse = await agent.initialize({
       protocolVersion: 1,
       clientCapabilities: {
-        auth: { _meta: { gateway: true } },
+        _meta: { gateway: true },
       } as any,
     });
     expect(initializeResponse.authMethods).not.toContainEqual(


### PR DESCRIPTION
TS SDK filters out unknown fields. Field `auth` isn't passed to the `initialize` method.
