### PR TITLE
fix: use current model's context window for usage_update size

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -48,6 +48,7 @@ import {
   listSessions,
   McpServerConfig,
   ModelInfo,
+  ModelUsage,
   Options,
   PermissionMode,
   Query,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1710,7 +1710,14 @@ describe("usage_update computation", () => {
       input,
       cancelled: false,
       cwd: "/test",
-      permissionMode: "default",
+      modes: {
+        currentModeId: "default",
+        availableModes: [],
+      },
+      models: {
+        currentModelId: "default",
+        availableModels: [],
+      },
       settingsManager: {} as any,
       accumulatedUsage: {
         inputTokens: 0,
@@ -1752,6 +1759,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1790,6 +1798,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1829,6 +1838,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1869,6 +1879,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1924,6 +1935,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1954,6 +1966,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -1982,6 +1995,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
@@ -2026,6 +2040,7 @@ describe("usage_update computation", () => {
           },
         },
       }),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });


### PR DESCRIPTION
The `usage_update` notification reports `size: 200000` even when the active model has a 1M context window (e.g. `opus[1m]`), causing clients to display incorrect context utilization (e.g. `689k/200k (344.3%)` instead of `689k/1000k (68.9%)`).

Four bugs fixed:

- **Min across all models**: The original code used `Math.min` across all `modelUsage` entries, so subagent models (Sonnet/Haiku with 200k windows) dragged down the reported size for the main Opus 1M model. Now tracks the top-level assistant model and looks up its context window specifically.
- **Model name mismatch**: The SDK's streaming path keys `modelUsage` by the requested model alias (e.g. `claude-opus-4-6`) while `BetaMessage.model` on assistant messages has the resolved API response model (e.g. `claude-opus-4-6-20250514`). The exact-match lookup always missed, falling back to the hardcoded 200k default. Now falls back to prefix matching, preferring the longest/most-specific match.
- **Synthetic messages corrupt model tracking**: `/compact` and similar commands emit assistant messages with `model: "<synthetic>"`. These were updating `lastAssistantModel`, causing the next `usage_update` to miss the `modelUsage` lookup and fall back to the 200k default. Now filters out `<synthetic>` models.
- **Stale usage after compaction**: No `usage_update` was sent on `compact_boundary`, so clients kept showing the pre-compaction context size (e.g. `944k/1m`) right after "Compacting completed" until the next full turn. Now sends `used: 0` immediately on compaction. This is a deliberate approximation — the exact post-compaction size isn't known until the SDK's next API call, which replaces it within seconds. The alternative (no update) is worse UX: showing a full context bar right after compaction.

Eight new tests cover: token sum correctness, current-model context window lookup, model switching, subagent isolation, prefix matching in both directions, and synthetic message filtering.

Note: `bin/test` (local CI validation script) is cherry-picked from #353.

Would fix `agent-shell`'s usage indicator which currently has to defend against this broken math: https://github.com/xenodium/agent-shell/pull/364

## Testing

- [x] Manual riding with it for a bit.
