### PR TITLE
fix: clear CLAUDECODE env to prevent nested-session detection

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1227,6 +1227,7 @@ export class ClaudeAcpAgent implements Agent {
       ...userProvidedOptions,
       env: {
         ...process.env,
+        CLAUDECODE: "", // Prevent nested-session detection when spawned from within Claude Code
         ...userProvidedOptions?.env,
         ...createEnvForGateway(this.gatewayAuthMeta),
       },
@@ -1303,11 +1304,19 @@ export class ClaudeAcpAgent implements Agent {
       initializationResult = await q.initializationResult();
     } catch (error) {
       if (
-        creationOpts.resume &&
         error instanceof Error &&
         error.message === "Query closed before response received"
       ) {
-        throw RequestError.resourceNotFound(sessionId);
+        if (creationOpts.resume) {
+          throw RequestError.resourceNotFound(sessionId);
+        }
+        // For new sessions, provide a meaningful error instead of generic "Internal error"
+        throw RequestError.internalError(
+          undefined,
+          "Claude Code process exited before initialization completed. " +
+            "Ensure Claude Code is installed and accessible. " +
+            "You can set CLAUDE_CODE_EXECUTABLE to the path of the Claude CLI.",
+        );
       }
       throw error;
     }


### PR DESCRIPTION
## Problem

When `claude-agent-acp` is spawned from within an existing Claude Code session (e.g. via `acpx` or other agent orchestrators), the parent process sets `CLAUDECODE=1`. This environment variable is inherited by the spawned subprocess, causing Claude Code to detect a "nested session" and exit immediately during initialization.

The result is a generic `-32603 Internal error` with `data.details: "Query closed before response received"` on every `session/new` call. This affects both `exec` (one-shot) and persistent session modes.

**Reproduction:**
```bash
# From inside a Claude Code session:
acpx claude exec 'hello'
# -> [error] RUNTIME: Internal error
```

## Root Cause

`CLAUDECODE=1` is set by Claude Code in its shell environment. When `claude-agent-acp` spawns a new Claude Code subprocess via the SDK's `query()`, it passes `...process.env` which includes `CLAUDECODE=1`. The child process sees this and refuses to start (nested-session protection).

## Fix

1. **Clear `CLAUDECODE` in subprocess env** — Set `CLAUDECODE: ""` in the env object passed to `query()`, so the spawned instance starts normally. This mirrors what other Claude Code wrappers do (e.g. cmux's wrapper script uses `unset CLAUDECODE`).

2. **Improve error handling for `session/new`** — The v0.20.0 fix for "Query closed before response received" (PR #363) only covered the `loadSession` path (`creationOpts.resume`). The same error on `newSession` was left unhandled, producing an opaque "Internal error". Now it returns a meaningful message suggesting to check Claude Code installation.

## Testing

Verified on macOS arm64 with:
- acpx 0.3.0
- Claude Code CLI 2.1.74
- Node v25.8.0

Before fix: `acpx claude exec` always fails with `Internal error` when run from within Claude Code.
After fix: works correctly, Claude responds normally.