### PR TITLE
Fix prompt hang when user message replay is absent

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -488,7 +488,13 @@ export class ClaudeAcpAgent implements Agent {
     const promptUuid = randomUUID();
     userMessage.uuid = promptUuid;
 
-    let promptReplayed = false;
+    // backgroundInitPending tracks whether a system "init" message arrived
+    // without any subsequent activity (stream_event or assistant messages).
+    // A background task that completed after the previous prompt loop ended
+    // produces init → result with nothing in between. Our own prompt's
+    // processing always generates stream_event / assistant messages before
+    // its result, so the flag gets cleared before we see the result.
+    let backgroundInitPending = false;
 
     if (session.promptRunning) {
       session.input.push(userMessage);
@@ -499,9 +505,6 @@ export class ClaudeAcpAgent implements Agent {
       if (cancelled) {
         return { stopReason: "cancelled" };
       }
-      // The replay resolved the promise, mark in this loop too,
-      // so we don't treat the next result as a background task's result.
-      promptReplayed = true;
     } else {
       session.input.push(userMessage);
     }
@@ -524,6 +527,10 @@ export class ClaudeAcpAgent implements Agent {
           case "system":
             switch (message.subtype) {
               case "init":
+                // A new processing cycle started. If this is a
+                // background task, its result will follow immediately
+                // without intervening stream_event / assistant messages.
+                backgroundInitPending = true;
                 break;
               case "status": {
                 if (message.status === "compacting") {
@@ -548,7 +555,7 @@ export class ClaudeAcpAgent implements Agent {
                     content: { type: "text", text: "\n\nCompacting completed." },
                   },
                 });
-                promptReplayed = true;
+                backgroundInitPending = false;
                 break;
               }
               case "local_command_output": {
@@ -559,7 +566,7 @@ export class ClaudeAcpAgent implements Agent {
                     content: { type: "text", text: message.content },
                   },
                 });
-                promptReplayed = true;
+                backgroundInitPending = false;
                 break;
               }
               case "hook_started":
@@ -605,11 +612,13 @@ export class ClaudeAcpAgent implements Agent {
               });
             }
 
-            if (!promptReplayed) {
-              // This result is from a background task that finished after
-              // the previous prompt loop ended. Consume it and continue
-              // waiting for our own prompt's result.
+            if (backgroundInitPending) {
+              // This result immediately followed an init with no
+              // intervening activity — it belongs to a background task
+              // that finished after the previous prompt loop ended.
+              // Consume it and continue waiting for our own result.
               this.logger.log(`Session ${params.sessionId}: consuming background task result`);
+              backgroundInitPending = false;
               break;
             }
 
@@ -671,6 +680,9 @@ export class ClaudeAcpAgent implements Agent {
             break;
           }
           case "stream_event": {
+            // Stream events indicate active processing for our prompt,
+            // so clear any pending background init.
+            backgroundInitPending = false;
             for (const notification of streamEventToAcpNotifications(
               message,
               params.sessionId,
@@ -695,9 +707,9 @@ export class ClaudeAcpAgent implements Agent {
             // Check for prompt replay
             if (message.type === "user" && "uuid" in message && message.uuid) {
               if (message.uuid === promptUuid) {
-                // Our own prompt was replayed back — we're now processing
-                // our prompt's response (not a background task's).
-                promptReplayed = true;
+                // Our own prompt was replayed back — clear any pending
+                // background init since we're now processing our prompt.
+                backgroundInitPending = false;
                 break;
               }
               const pending = session.pendingMessages.get(message.uuid as string);
@@ -714,6 +726,9 @@ export class ClaudeAcpAgent implements Agent {
                 break;
               }
             }
+
+            // Non-replay user/assistant messages indicate active processing.
+            backgroundInitPending = false;
 
             // Store latest assistant usage (excluding subagents)
             if ((message.message as any).usage && message.parent_tool_use_id === null) {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1503,6 +1503,272 @@ describe("stop reason propagation", () => {
       }),
     ).rejects.toThrow("Internal error");
   });
+
+  // Regression tests for #400 (87a0886): promptReplayed bug causes prompt to
+  // hang forever when no user message replay arrives before the result.
+
+  function injectSessionNoReplay(agent: ClaudeAcpAgent, messages: any[]) {
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      // Consume the user message from input (as Claude Code does) but do NOT
+      // replay it back through the query iterator — this matches real-world
+      // behaviour observed in wire logs.
+      const iter = input[Symbol.asyncIterator]();
+      await iter.next();
+      yield* messages;
+    }
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      permissionMode: "default",
+      settingsManager: {} as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+      abortController: new AbortController(),
+    };
+  }
+
+  it("should return result even when user message is not replayed", async () => {
+    const agent = createMockAgent();
+    injectSessionNoReplay(agent, [
+      createResultMessage({ subtype: "success", stop_reason: null, is_error: false }),
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+  });
+
+  it("should return result when init precedes result with stream events and no replay", async () => {
+    // When our prompt's processing starts with an init, there will always
+    // be stream_events (Claude streaming its response) before the result.
+    // The stream_event clears the backgroundInitPending flag so the result
+    // is accepted as ours.
+    const agent = createMockAgent();
+    injectSessionNoReplay(agent, [
+      { type: "system", subtype: "init", session_id: "test-session" },
+      {
+        type: "stream_event",
+        event: { type: "message_start", message: { role: "assistant", content: [] } },
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      createResultMessage({ subtype: "success", stop_reason: null, is_error: false }),
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+  });
+
+  it("should consume init-then-result as background task even with later activity", async () => {
+    // Background task produces init → result (no stream events between).
+    // Our prompt then generates stream_events → result.
+    const agent = createMockAgent();
+
+    const backgroundTaskResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+    backgroundTaskResult.usage.input_tokens = 100;
+    backgroundTaskResult.usage.output_tokens = 50;
+
+    const promptResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+
+    injectSessionNoReplay(agent, [
+      // Background task: init immediately followed by result
+      { type: "system", subtype: "init", session_id: "test-session" },
+      backgroundTaskResult,
+      // Our prompt's processing: stream events then result
+      {
+        type: "stream_event",
+        event: { type: "message_start", message: { role: "assistant", content: [] } },
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      promptResult,
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    expect(response.usage?.inputTokens).toBe(
+      backgroundTaskResult.usage.input_tokens + promptResult.usage.input_tokens,
+    );
+    expect(response.usage?.outputTokens).toBe(
+      backgroundTaskResult.usage.output_tokens + promptResult.usage.output_tokens,
+    );
+  });
+
+  it("should return result when stream events precede result without replay", async () => {
+    const agent = createMockAgent();
+    injectSessionNoReplay(agent, [
+      {
+        type: "assistant",
+        message: { role: "assistant", content: [{ type: "text", text: "hello" }] },
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      createResultMessage({ subtype: "success", stop_reason: null, is_error: false }),
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+  });
+
+  it("should still consume background task result when replay IS present", async () => {
+    // This preserves the original intent of #400: if a background task result
+    // arrives before our replay, consume it and use the post-replay result.
+    const agent = createMockAgent();
+    const input = new Pushable<any>();
+
+    const backgroundTaskResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+    backgroundTaskResult.usage.input_tokens = 100;
+    backgroundTaskResult.usage.output_tokens = 50;
+
+    const promptResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+
+    async function* messageGenerator() {
+      // Background task init + result arrive before our prompt's replay
+      yield { type: "system", subtype: "init", session_id: "test-session" };
+      yield backgroundTaskResult;
+
+      // Now the prompt's user message replay arrives
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage } = await iter.next();
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: "test-session",
+        isReplay: true,
+      };
+
+      // Then the prompt's own result
+      yield promptResult;
+    }
+
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cwd: "/tmp/test",
+      cancelled: false,
+      permissionMode: "default",
+      settingsManager: {} as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      abortController: new AbortController(),
+      configOptions: [],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+    };
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    // Usage should include both background task and prompt result tokens
+    expect(response.usage?.inputTokens).toBe(
+      backgroundTaskResult.usage.input_tokens + promptResult.usage.input_tokens,
+    );
+    expect(response.usage?.outputTokens).toBe(
+      backgroundTaskResult.usage.output_tokens + promptResult.usage.output_tokens,
+    );
+  });
+
+  it("should return result with replay arriving after user message with different uuid", async () => {
+    // Simulates Claude Code replaying the user message but with a different
+    // UUID than the one set on the input message.
+    const agent = createMockAgent();
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      await iter.next();
+      // Replay with a DIFFERENT uuid than what was set on the input
+      yield {
+        type: "user",
+        message: { role: "user", content: [{ type: "text", text: "test" }] },
+        parent_tool_use_id: null,
+        uuid: randomUUID(), // different uuid!
+        session_id: "test-session",
+        isReplay: true,
+      };
+      yield createResultMessage({ subtype: "success", stop_reason: null, is_error: false });
+    }
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      permissionMode: "default",
+      settingsManager: {} as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+      abortController: new AbortController(),
+    };
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+  });
 });
 
 describe("session/close", () => {


### PR DESCRIPTION
> [!IMPORTANT]
> Claude thinks this isn't necessary if https://github.com/zed-industries/claude-agent-acp/pull/353 merges. I only became aware of the issue because my dev integration branch got reset to upstream/main and didn't have this replayed on top of it.

Commit 87a0886 (#400) introduced a `promptReplayed` flag to distinguish background task results from the current prompt's result. The flag starts `false` and only becomes `true` when the user message is replayed through the query stream with a matching UUID.

In practice, Claude Code either doesn't replay the user message or replays it with a different UUID. This causes `promptReplayed` to stay `false` for every prompt, so the result is always discarded as a "background task result". The `while(true)` loop then blocks forever waiting for a result that will never come — **hanging every prompt indefinitely**.

Wire logs from two independent sessions confirm:
1. `session/prompt` request is sent
2. Notifications flow normally (stream events, tool calls, agent messages)
3. stderr shows `"consuming background task result"` — the result is discarded
4. No response to the `session/prompt` request is ever sent
5. The client hangs forever (no timeout mechanism)

### Fix

Replace `promptReplayed` with `backgroundInitPending` — a flag that detects the actual fingerprint of a background task completion: a system `init` message immediately followed by a `result` with no intervening `stream_event` or `assistant` messages.

This works because:
- **Background tasks** produce `init → result` with nothing in between
- **Our prompt's processing** produces `init → stream_events → result` (Claude always streams its response before the result)
- The `stream_event` / `assistant` messages clear `backgroundInitPending`, so our result is accepted

This approach doesn't depend on user message replay at all, making it robust regardless of whether `replay-user-messages` is working correctly in the SDK.

### Tests added (7 new)

- [x] Result accepted when no user message replay arrives (the core regression)
- [x] Result accepted when `init` + stream events precede result without replay
- [x] `init → result` (no activity) correctly consumed as background task, followed by our result with stream events
- [x] Result accepted when stream events precede result without replay
- [x] Background task consumed when replay IS present (preserves original #400 intent)
- [x] Result accepted when replay has mismatched UUID
- [x] Existing background task test continues to pass
- [ ] Manual burn-in verification
