### PR TITLE
Remove interrupt flag from deny responses

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1020,7 +1020,6 @@ export class ClaudeAcpAgent implements Agent {
         return {
           behavior: "deny",
           message: "Session not found",
-          interrupt: true,
         };
       }
 
@@ -1086,7 +1085,6 @@ export class ClaudeAcpAgent implements Agent {
           return {
             behavior: "deny",
             message: "User rejected request to exit plan mode.",
-            interrupt: true,
           };
         }
       }
@@ -1152,7 +1150,6 @@ export class ClaudeAcpAgent implements Agent {
         return {
           behavior: "deny",
           message: "User refused permission to run tool",
-          interrupt: true,
         };
       }
     };


### PR DESCRIPTION
Now that the models are doing more parallel tool calls, we don't
necessarily want to interrupt in all of these cases.

Closes #402 
