### PR TITLE
fix session close method name

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -850,7 +850,7 @@ export class ClaudeAcpAgent implements Agent {
     await session.query.interrupt();
   }
 
-  async unstable_sessionClose(params: CloseSessionRequest): Promise<CloseSessionResponse> {
+  async unstable_closeSession(params: CloseSessionRequest): Promise<CloseSessionResponse> {
     const session = this.sessions[params.sessionId];
     if (!session) {
       throw new Error("Session not found");

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1565,7 +1565,7 @@ describe("session/close", () => {
 
     expect(agent.sessions["session-1"]).toBeDefined();
 
-    const result = await agent.unstable_sessionClose({ sessionId: "session-1" });
+    const result = await agent.unstable_closeSession({ sessionId: "session-1" });
 
     expect(result).toEqual({});
     expect(agent.sessions["session-1"]).toBeUndefined();
@@ -1578,7 +1578,7 @@ describe("session/close", () => {
 
     expect(session.abortController.signal.aborted).toBe(false);
 
-    await agent.unstable_sessionClose({ sessionId: "session-2" });
+    await agent.unstable_closeSession({ sessionId: "session-2" });
 
     expect(session.abortController.signal.aborted).toBe(true);
   });
@@ -1586,7 +1586,7 @@ describe("session/close", () => {
   it("should throw when closing a non-existent session", async () => {
     const agent = createMockAgent();
 
-    await expect(agent.unstable_sessionClose({ sessionId: "non-existent" })).rejects.toThrow(
+    await expect(agent.unstable_closeSession({ sessionId: "non-existent" })).rejects.toThrow(
       "Session not found",
     );
   });
@@ -1596,7 +1596,7 @@ describe("session/close", () => {
     injectSession(agent, "session-a");
     injectSession(agent, "session-b");
 
-    await agent.unstable_sessionClose({ sessionId: "session-a" });
+    await agent.unstable_closeSession({ sessionId: "session-a" });
 
     expect(agent.sessions["session-a"]).toBeUndefined();
     expect(agent.sessions["session-b"]).toBeDefined();


### PR DESCRIPTION
that's the nice part about unit tests, all green and still broken...

Relates to https://github.com/zed-industries/claude-agent-acp/pull/409.