### PR TITLE
Fix handling of local-only slash commands

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -479,8 +479,7 @@ export class ClaudeAcpAgent implements Agent {
     // background task result.
     const firstText = params.prompt[0]?.type === "text" ? params.prompt[0].text : "";
     const isLocalOnlyCommand =
-      firstText.startsWith("/") &&
-      LOCAL_ONLY_COMMANDS.has(firstText.split(" ", 1)[0]);
+      firstText.startsWith("/") && LOCAL_ONLY_COMMANDS.has(firstText.split(" ", 1)[0]);
     if (isLocalOnlyCommand) {
       promptReplayed = true;
     }


### PR DESCRIPTION
Instead of parsing <local-command-stdout> tags from the message stream, intercept these commands early and forward
the clean result from the success handler directly to the client. Applies to /context, /heapdump, and /extra-usage.
