### PR TITLE
fix: only load current workspace's sessions instead of all sessions

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -275,6 +275,7 @@ export class ClaudeAcpAgent implements Agent {
   clientCapabilities?: ClientCapabilities;
   logger: Logger;
   gatewayAuthMeta?: GatewayAuthMeta;
+  workspaceCwd?: string;
 
   constructor(client: AgentSideConnection, logger?: Logger) {
     this.sessions = {};
@@ -369,6 +370,10 @@ export class ClaudeAcpAgent implements Agent {
       throw RequestError.authRequired();
     }
 
+    if (params.cwd && !this.workspaceCwd) {
+      this.workspaceCwd = params.cwd;
+    }
+
     const response = await this.createSession(params, {
       // Revisit these meta values once we support resume
       resume: (params._meta as NewSessionMeta | undefined)?.claudeCode?.options?.resume,
@@ -423,7 +428,8 @@ export class ClaudeAcpAgent implements Agent {
   }
 
   async listSessions(params: ListSessionsRequest): Promise<ListSessionsResponse> {
-    const sdk_sessions = await listSessions({ dir: params.cwd ?? undefined });
+    const cwd = params.cwd ?? this.workspaceCwd;
+    const sdk_sessions = await listSessions({ dir: cwd });
     const sessions = [];
 
     for (const session of sdk_sessions) {


### PR DESCRIPTION
### Summary
When Zed (or another ACP client) opens the sessions list, it doesn't send a `cwd` parameter — the agent is spawned per-workspace, but the workspace path isn't passed at startup. Unlike Zed Agent, Claude Agent can only load sessions that were spawned under current workspace. We will encounter an error when opening sessions spawned from another workspace. I find this behavior unwelcome and annoying.

<img width="2315" height="1292" alt="image" src="https://github.com/user-attachments/assets/d6e1f868-fa7a-4fea-88dd-b1d0c035bab4" />

But since the `cwd` is passed from Zed side, there is no way the listSession() knows where current workspace is, I suggest a workaround. When a workspace is open, it opens a new agent session that includes the `cwd`, so we can cache the `cwd` to use later. 
### Changes
This PR caches the `cwd` from the first `newSession` call and uses it as a fallback in `listSessions`, so subsequent session list requests are scoped to the current workspace rather than showing all sessions across every project.