### PR TITLE
fix: correct null check for gatewayAuthMeta in subscription validation

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1417,7 +1417,7 @@ export class ClaudeAcpAgent implements Agent {
     if (
       shouldHideClaudeAuth() &&
       initializationResult.account.subscriptionType &&
-      this.gatewayAuthMeta === null
+      !this.gatewayAuthMeta
     ) {
       throw RequestError.authRequired(
         undefined,


### PR DESCRIPTION
## Summary

- `gatewayAuthMeta` is declared as an optional property (`undefined` when unset), but the subscription validation compared it against `null`
- This made the condition always false, so `--hide-claude-auth` never blocked claude.ai subscription users when no gateway was configured
- Changed `=== null` to `!this.gatewayAuthMeta` to match the actual property semantics

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm run lint` passes
- [x] All 6 authorization tests pass