### PR TITLE
fix: include both stdout and stderr in Bash tool output

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -481,7 +481,7 @@ export function toolUpdateFromToolResult(
         result.type === "bash_code_execution_result"
       ) {
         const bashResult = result as BetaBashCodeExecutionResultBlock;
-        output = bashResult.stdout || bashResult.stderr || "";
+        output = [bashResult.stdout, bashResult.stderr].filter(Boolean).join("\n");
         exitCode = bashResult.return_code;
       } else if (typeof result === "string") {
         output = result;


### PR DESCRIPTION
## Summary

- When a Bash tool execution produced both stdout and stderr, only stdout was shown due to the `||` operator short-circuiting
- Changed to concatenate both streams with `[stdout, stderr].filter(Boolean).join("\n")` so error output is no longer silently dropped

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm run lint` passes
- [x] All 34 tools tests pass