### PR TITLE
fix: always send valid used value in usage_update notification

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -570,21 +570,20 @@ export class ClaudeAcpAgent implements Agent {
             const contextWindowSize =
               contextWindows.length > 0 ? Math.min(...contextWindows) : 200000;
 
-            // Send usage_update notification
-            if (lastAssistantTotalUsage !== null) {
-              await this.client.sessionUpdate({
-                sessionId: params.sessionId,
-                update: {
-                  sessionUpdate: "usage_update",
-                  used: lastAssistantTotalUsage,
-                  size: contextWindowSize,
-                  cost: {
-                    amount: message.total_cost_usd,
-                    currency: "USD",
-                  },
+            // Send usage_update notification — always send with a valid
+            // number so clients don't receive `used: null` (see #375).
+            await this.client.sessionUpdate({
+              sessionId: params.sessionId,
+              update: {
+                sessionUpdate: "usage_update",
+                used: lastAssistantTotalUsage ?? 0,
+                size: contextWindowSize,
+                cost: {
+                  amount: message.total_cost_usd,
+                  currency: "USD",
                 },
-              });
-            }
+              },
+            });
 
             if (!promptReplayed) {
               // This result is from a background task that finished after


### PR DESCRIPTION
Fixes #375

## Summary

- When no assistant message with usage was seen before a `result` message (e.g. `output_tokens=0` or compact-only turns), `lastAssistantTotalUsage` remained `null`
- Although guarded by `if (lastAssistantTotalUsage !== null)`, the usage_update was simply skipped — some clients still received `used: null` causing `Invalid params` errors
- Now always sends the `usage_update` with `used: 0` as fallback when no usage data is available

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm run lint` passes
- [x] All tests pass (2 pre-existing Windows path separator failures unrelated)