### PR TITLE
fix: prevent prompt loop hang when cancel races with first result

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -586,16 +586,20 @@ export class ClaudeAcpAgent implements Agent {
               });
             }
 
+            // Check cancelled before promptReplayed — when a cancel races
+            // with the first result, promptReplayed is still false and the
+            // result would be consumed as a background task, blocking the
+            // loop forever (see #442).
+            if (session.cancelled) {
+              return { stopReason: "cancelled" };
+            }
+
             if (!promptReplayed) {
               // This result is from a background task that finished after
               // the previous prompt loop ended. Consume it and continue
               // waiting for our own prompt's result.
               this.logger.log(`Session ${params.sessionId}: consuming background task result`);
               break;
-            }
-
-            if (session.cancelled) {
-              return { stopReason: "cancelled" };
             }
 
             // Build the usage response


### PR DESCRIPTION
Fixes #442

## Summary

- When `cancel()` was called immediately after a prompt, the result message arrived before `promptReplayed` was set to `true`
- The `!promptReplayed` check consumed it as a "background task result", making the `session.cancelled` check unreachable
- The loop then blocked forever on `query.next()` since no further messages would arrive
- Fix: move the `session.cancelled` check **before** the `!promptReplayed` check so cancellation is always detected

## Test plan

- [x] `npm run build` compiles clean
- [x] `npm run lint` passes
- [x] All unit tests pass
- [x] Logic verified against the race condition sequence described in #442