### PR TITLE
fix: Add explicit type checks for MCP servers (http/sse)

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1256,7 +1256,8 @@ export class ClaudeAcpAgent implements Agent {
     const mcpServers: Record<string, McpServerConfig> = {};
     if (Array.isArray(params.mcpServers)) {
       for (const server of params.mcpServers) {
-        if ("type" in server) {
+        if ("type" in server && (server.type === "http" || server.type === "sse")) {
+          // HTTP or SSE type MCP server
           mcpServers[server.name] = {
             type: server.type,
             url: server.url,
@@ -1265,6 +1266,7 @@ export class ClaudeAcpAgent implements Agent {
               : undefined,
           };
         } else {
+          // Stdio type MCP server (with or without explicit type field)
           mcpServers[server.name] = {
             type: "stdio",
             command: server.command,


### PR DESCRIPTION
As mentioned in https://github.com/agentclientprotocol/claude-agent-acp/issues/468#issuecomment-4141841845

IDEA always explicitly passes the MCP server type; for example, even if the type is `stdio`, IDEA will still pass `type: 'stdio'`.

This causes the following code to enter the http or sse branch due to the presence of the 'type' field

<img width="644" height="483" alt="Image" src="https://github.com/user-attachments/assets/4919ae2a-456f-461a-93b8-d914489f444c" />

As part of defensive programming, change this line to a more robust check:

`if ("type" in server && (server.type === "http" || server.type === "sse"))`