### PR TITLE
fix: allow opt-out of session_state_changed via env var

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -123,6 +123,7 @@ type Session = {
   pendingMessages: Map<string, { resolve: (cancelled: boolean) => void; order: number }>;
   nextPendingOrder: number;
   abortController: AbortController;
+  useSessionStateEvents: boolean;
 };
 
 type BackgroundTerminal =
@@ -681,6 +682,12 @@ export class ClaudeAcpAgent implements Agent {
               default:
                 unreachable(message, this.logger);
                 break;
+            }
+            // When session state events are disabled (CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=0),
+            // session_state_changed(idle) will never arrive. Return immediately
+            // using the stopReason set by the result subtype above.
+            if (!session.useSessionStateEvents) {
+              return { stopReason, usage: sessionUsage(session) };
             }
             break;
           }
@@ -1364,8 +1371,11 @@ export class ClaudeAcpAgent implements Agent {
         ...process.env,
         ...userProvidedOptions?.env,
         ...createEnvForGateway(this.gatewayAuthMeta),
-        // Opt-in to session state events like when the agent is idle
-        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: "1",
+        // Allow users to opt out of session state events by setting
+        // CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=0 in their environment,
+        // e.g. when the Claude Code binary does not support this feature.
+        CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS:
+          process.env.CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS ?? "1",
       },
       // Override certain fields that must be controlled by ACP
       cwd: params.cwd,
@@ -1520,6 +1530,8 @@ export class ClaudeAcpAgent implements Agent {
       pendingMessages: new Map(),
       nextPendingOrder: 0,
       abortController,
+      useSessionStateEvents:
+        (process.env.CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS ?? "1") !== "0",
     };
 
     return {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1348,6 +1348,7 @@ describe("stop reason propagation", () => {
       pendingMessages: new Map(),
       nextPendingOrder: 0,
       abortController: new AbortController(),
+      useSessionStateEvents: true,
     };
   }
 
@@ -1483,6 +1484,7 @@ describe("stop reason propagation", () => {
         cachedWriteTokens: 0,
       },
       abortController: new AbortController(),
+      useSessionStateEvents: true,
       configOptions: [],
       promptRunning: false,
       pendingMessages: new Map(),
@@ -1560,6 +1562,7 @@ describe("session/close", () => {
       pendingMessages: new Map(),
       nextPendingOrder: 0,
       abortController: new AbortController(),
+      useSessionStateEvents: true,
     };
     return agent.sessions[sessionId]!;
   }
@@ -1730,6 +1733,7 @@ describe("usage_update computation", () => {
       pendingMessages: new Map(),
       nextPendingOrder: 0,
       abortController: new AbortController(),
+      useSessionStateEvents: true,
     };
   }
 


### PR DESCRIPTION
## Summary

- Fixes #497
- When `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=0` is set in the environment, the prompt loop returns the `PromptResponse` directly from the `result` message handler instead of waiting for `session_state_changed(idle)` which will never arrive on older Claude Code binaries
- The env var defaults to `"1"` (enabled) to preserve existing behavior
- Respects user's env var instead of hardcoding `"1"`, allowing deterministic opt-out

## Changes

1. **`Session.useSessionStateEvents`** — new boolean flag on the session, derived from the env var at session creation
2. **`createSession` env override** — `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS` now respects `process.env` instead of always hardcoding `"1"`
3. **Result handler fallback** — after the inner result subtype switch, returns immediately when `useSessionStateEvents` is `false`

## Test plan

- [x] With `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS` unset (default): behavior unchanged, waits for `session_state_changed(idle)`
- [x] With `CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS=0`: prompt returns immediately after `result(success)`, no hang
- [x] With older Claude Code binary + env var set to `0`: client receives `PromptResponse` and does not deadlock
