### PR TITLE
feat: Add separate Claude and Console terminal logins

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -307,23 +307,40 @@ export class ClaudeAcpAgent implements Agent {
       },
     };
 
-    const terminalAuthMethod: any = {
-      description: "Run `claude /login` in the terminal",
-      name: "Log in with Claude",
-      id: "claude-login",
-      type: "terminal",
-      args: ["--cli"],
-    };
     const supportsTerminalAuth = request.clientCapabilities?.auth?.terminal === true;
+    const supportsMetaTerminalAuth = request.clientCapabilities?._meta?.["terminal-auth"] === true;
+
+    const claudeLoginMethod: any = {
+      description: "Use Claude subscription ",
+      name: "Claude Subscription",
+      id: "claude-ai-login",
+      type: "terminal",
+      args: ["--cli", "auth", "login", "--claudeai"],
+    };
+
+    const consoleLoginMethod: any = {
+      description: "Use Anthropic Console (API usage billing)",
+      name: "Anthropic Console",
+      id: "console-login",
+      type: "terminal",
+      args: ["--cli", "auth", "login", "--console"],
+    };
 
     // If client supports terminal-auth capability, use that instead.
-    const supportsMetaTerminalAuth = request.clientCapabilities?._meta?.["terminal-auth"] === true;
     if (supportsMetaTerminalAuth) {
-      terminalAuthMethod._meta = {
+      const baseArgs = process.argv.slice(1);
+      claudeLoginMethod._meta = {
         "terminal-auth": {
           command: process.execPath,
-          args: [...process.argv.slice(1), "--cli"],
+          args: [...baseArgs, "--cli", "auth", "login", "--claudeai"],
           label: "Claude Login",
+        },
+      };
+      consoleLoginMethod._meta = {
+        "terminal-auth": {
+          command: process.execPath,
+          args: [...baseArgs, "--cli", "auth", "login", "--console"],
+          label: "Anthropic Console Login",
         },
       };
     }
@@ -359,8 +376,9 @@ export class ClaudeAcpAgent implements Agent {
       },
       authMethods: [
         ...(!shouldHideClaudeAuth() && (supportsTerminalAuth || supportsMetaTerminalAuth)
-          ? [terminalAuthMethod]
+          ? [claudeLoginMethod]
           : []),
+        ...(supportsTerminalAuth || supportsMetaTerminalAuth ? [consoleLoginMethod] : []),
         ...(supportsGatewayAuth ? [gatewayAuthMethod] : []),
       ],
     };

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -123,14 +123,17 @@ describe("authorization", () => {
       } as any,
     });
     expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "claude-login" }),
+      expect.objectContaining({ id: "claude-ai-login" }),
+    );
+    expect(initializeResponse.authMethods).not.toContainEqual(
+      expect.objectContaining({ id: "console-login" }),
     );
     expect(initializeResponse.authMethods).toContainEqual(
       expect.objectContaining({ id: "gateway" }),
     );
   });
 
-  it("hide terminal auth even when terminal-auth is set", async () => {
+  it("hide claude auth but still show console login when terminal-auth is set", async () => {
     const [agent] = await createAgentMock();
     vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
 
@@ -140,7 +143,30 @@ describe("authorization", () => {
         _meta: { "terminal-auth": true },
       },
     });
-    expect(initializeResponse.authMethods).toStrictEqual([]);
+    expect(initializeResponse.authMethods).not.toContainEqual(
+      expect.objectContaining({ id: "claude-ai-login" }),
+    );
+    expect(initializeResponse.authMethods).toContainEqual(
+      expect.objectContaining({ id: "console-login" }),
+    );
+  });
+
+  it("hide claude auth but still show console login with terminal capability", async () => {
+    const [agent] = await createAgentMock();
+    vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
+
+    const initializeResponse = await agent.initialize({
+      protocolVersion: 1,
+      clientCapabilities: {
+        auth: { terminal: true },
+      },
+    });
+    expect(initializeResponse.authMethods).not.toContainEqual(
+      expect.objectContaining({ id: "claude-ai-login" }),
+    );
+    expect(initializeResponse.authMethods).toContainEqual(
+      expect.objectContaining({ id: "console-login" }),
+    );
   });
 
   it("show claude authentication", async () => {
@@ -152,7 +178,10 @@ describe("authorization", () => {
     });
 
     expect(initializeResponse.authMethods).toContainEqual(
-      expect.objectContaining({ id: "claude-login" }),
+      expect.objectContaining({ id: "claude-ai-login" }),
+    );
+    expect(initializeResponse.authMethods).toContainEqual(
+      expect.objectContaining({ id: "console-login" }),
     );
   });
 });


### PR DESCRIPTION
Expose distinct terminal auth methods for Claude subscription and
Anthropic Console, including terminal-auth metadata for both.
