### PR TITLE
fix: prioritize ANTHROPIC_MODEL env var over settings.model in model …

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1698,7 +1698,16 @@ async function getAvailableModels(
 
   let currentModel = models[0];
 
-  if (settings.model) {
+  // Model priority (highest to lowest):
+  // 1. ANTHROPIC_MODEL environment variable
+  // 2. settings.model (user configuration)
+  // 3. models[0] (default first model)
+  if (process.env.ANTHROPIC_MODEL) {
+    const match = resolveModelPreference(models, process.env.ANTHROPIC_MODEL);
+    if (match) {
+      currentModel = match;
+    }
+  } else if (settings.model) {
     const match = resolveModelPreference(models, settings.model);
     if (match) {
       currentModel = match;


### PR DESCRIPTION
Title:
  fix: ANTHROPIC_MODEL env var not respected in ACP agent model selection                                                                                                            
                                                                  
  Body:                                                                                                                                                                              
   
  ## Summary                                                                                                                                                                         
                                                                  
  The `ANTHROPIC_MODEL` environment variable is not being respected when using Claude Code via the ACP (Agent Client Protocol). This causes users who set their preferred model via  
  environment variable to have their setting ignored, with the default model (`claude-sonnet-4-6`) being used instead.
                                                                                                                                                                                     
  ## Problem                                                      

  When using Claude Code through ACP integrations (e.g., agent platforms), users expect the `ANTHROPIC_MODEL` environment variable to control which model is used for LLM requests.  
  However, the current implementation only checks `settings.model` (from configuration files) and completely ignores `ANTHROPIC_MODEL`.
                                                                                                                                                                                     
  ## Root Cause                                                   

  In `src/acp-agent.ts`, the `getAvailableModels` function only checks `settings.model`:

  ```typescript
  let currentModel = models[0];

  if (settings.model) {                                                                                                                                                              
    const match = resolveModelPreference(models, settings.model);
    if (match) {                                                                                                                                                                     
      currentModel = match;                                       
    }
  }

  The ANTHROPIC_MODEL environment variable is never read, so environment-based model configuration is silently ignored.                                                              
   
  Reproduction                                                                                                                                                                       
                                                                  
  1. Set ANTHROPIC_MODEL=glm-4.7 (or any custom model)                                                                                                                               
  2. Start Claude Code via ACP protocol
  3. Send a prompt request                                                                                                                                                           
  4. Capture network traffic - the actual model used is claude-sonnet-4-6 instead of glm-4.7
                                                                                                                                                                                     
  Fix
                                                                                                                                                                                     
  Added priority-based model selection that respects the ANTHROPIC_MODEL environment variable, aligning with the main Claude Code CLI behavior:                                      
   
  // Model priority (highest to lowest):                                                                                                                                             
  // 1. ANTHROPIC_MODEL environment variable                      
  // 2. settings.model (user configuration)
  // 3. models[0] (default first model)                                                                                                                                              
  if (process.env.ANTHROPIC_MODEL) {
    const match = resolveModelPreference(models, process.env.ANTHROPIC_MODEL);                                                                                                       
    if (match) {                                                  
      currentModel = match;
    }
  } else if (settings.model) {
    const match = resolveModelPreference(models, settings.model);                                                                                                                    
    if (match) {
      currentModel = match;                                                                                                                                                          
    }                                                             
  }

  This matches the model selection priority used by the main Claude Code CLI.                                                                                                        
   
  Testing                                                                                                                                                                            
                                                                  
  - Verified ANTHROPIC_MODEL is now respected when set                                                                                                                               
  - Verified settings.model still works when ANTHROPIC_MODEL is not set
  - Verified default model (models[0]) is used when neither is set                                                                                                                   
                                                                                                                                                                                     
  Breaking Change
                                                                                                                                                                                     
  None - this fix makes behavior more consistent with user expectations and the main CLI.                                                                                            
   
