### PR TITLE
fix: add `auto` to valid modes in applySessionMode to fix mode cycling

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1006,6 +1006,7 @@ export class ClaudeAcpAgent implements Agent {
 
   private async applySessionMode(sessionId: string, modeId: string): Promise<void> {
     switch (modeId) {
+      case "auto":
       case "default":
       case "acceptEdits":
       case "bypassPermissions":


### PR DESCRIPTION
ACP version is `v0.25.0`. Should be the newest.

I get this error when pressing Shift+Tab to cycle through the modes:

```
Caused by:
    RPC request LspQuery failed: unknown buffer id 12884902333
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: Error handling request {
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: jsonrpc: '2.0',
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: id: 48,
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: method: 'session/set_config_option',
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: params: {
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: sessionId: '$UUID_GOES_HERE',
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: configId: 'mode',
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: value: 'auto'
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: }
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: } {
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: code: -32603,
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: message: 'Internal error',
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: data: { details: 'Invalid Mode' }
2026-04-05T21:46:02+00:00 WARN  [agent_servers::acp] agent stderr: }
2026-04-05T21:46:02+00:00 ERROR [agent_ui::config_options] Failed to set config option: Internal error: {
  "details": "Invalid Mode"
}
```

I looked through the code on both sides and I think what might be happening is, here are the modes:

https://github.com/agentclientprotocol/claude-agent-acp/blob/f422c7c9548f3b6834fabd23031df04de02b1202/src/acp-agent.ts#L236-L244

When a user gets to `bypassPermissions` and cycle again, the next selected mode is `auto` but that option seems to be missing from here:

https://github.com/agentclientprotocol/claude-agent-acp/blob/f422c7c9548f3b6834fabd23031df04de02b1202/src/acp-agent.ts#L1007-L1013

Could the maintainers please help verify and test?