### PR TITLE
Forward dropped SDK events to ACP clients

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -116,10 +116,6 @@ type Session = {
   cwd: string;
   settingsManager: SettingsManager;
   accumulatedUsage: AccumulatedUsage;
-  /** Cumulative cost in USD for this session (from SDK result messages) */
-  totalCostUsd: number;
-  /** Terminal reason from the last SDK result (e.g. "blocking_limit", "completed") */
-  lastTerminalReason: string | null;
   modes: SessionModeState;
   models: SessionModelState;
   configOptions: SessionConfigOption[];
@@ -490,9 +486,6 @@ export class ClaudeAcpAgent implements Agent {
       cachedReadTokens: 0,
       cachedWriteTokens: 0,
     };
-    session.totalCostUsd = 0;
-    session.lastTerminalReason = null;
-
     let lastAssistantTotalUsage: number | null = null;
     let lastAssistantModel: string | null = null;
     let lastContextWindowSize: number = 200000;
@@ -596,11 +589,7 @@ export class ClaudeAcpAgent implements Agent {
               }
               case "session_state_changed": {
                 if (message.state === "idle") {
-                  return {
-                    stopReason,
-                    usage: sessionUsage(session),
-                    _meta: sessionMeta(session),
-                  };
+                  return { stopReason, usage: sessionUsage(session) };
                 }
                 break;
               }
@@ -612,30 +601,23 @@ export class ClaudeAcpAgent implements Agent {
               case "task_notification":
               case "task_progress":
               case "elicitation_complete":
+                break;
               case "api_retry": {
-                // Forward API retry events so clients can observe transient failures,
-                // including the HTTP status code and typed error category.
+                // Forward API retry events via extNotification so clients can observe
+                // transient failures including HTTP status code and typed error category.
                 const retryMsg = message as any;
                 this.logger.error(
                   `API retry: attempt=${retryMsg.attempt}/${retryMsg.max_retries}, ` +
                   `httpStatus=${retryMsg.error_status}, error=${retryMsg.error}, ` +
                   `delay=${retryMsg.retry_delay_ms}ms`,
                 );
-                await this.client.sessionUpdate({
-                  sessionId: retryMsg.session_id,
-                  _meta: {
-                    apiRetry: {
-                      httpStatus: retryMsg.error_status ?? null,
-                      errorType: retryMsg.error ?? "unknown",
-                      attempt: retryMsg.attempt ?? 0,
-                      maxRetries: retryMsg.max_retries ?? 0,
-                      retryDelayMs: retryMsg.retry_delay_ms ?? 0,
-                    },
-                  },
-                  update: {
-                    sessionUpdate: "agent_message_chunk",
-                    content: { type: "text", text: "" },
-                  },
+                await this.client.extNotification("_claude/api-retry", {
+                  sessionId: params.sessionId,
+                  httpStatus: retryMsg.error_status ?? null,
+                  errorType: retryMsg.error ?? "unknown",
+                  attempt: retryMsg.attempt ?? 0,
+                  maxRetries: retryMsg.max_retries ?? 0,
+                  retryDelayMs: retryMsg.retry_delay_ms ?? 0,
                 });
                 break;
               }
@@ -650,10 +632,6 @@ export class ClaudeAcpAgent implements Agent {
             session.accumulatedUsage.outputTokens += message.usage.output_tokens;
             session.accumulatedUsage.cachedReadTokens += message.usage.cache_read_input_tokens;
             session.accumulatedUsage.cachedWriteTokens += message.usage.cache_creation_input_tokens;
-            session.totalCostUsd = message.total_cost_usd;
-            if ("terminal_reason" in message && message.terminal_reason) {
-              session.lastTerminalReason = message.terminal_reason as string;
-            }
 
             const matchingModelUsage = lastAssistantModel
               ? getMatchingModelUsage(message.modelUsage, lastAssistantModel)
@@ -776,7 +754,7 @@ export class ClaudeAcpAgent implements Agent {
                 handedOff = true;
                 // the current loop stops with end_turn,
                 // the loop of the next prompt continues running
-                return { stopReason: "end_turn", usage: sessionUsage(session), _meta: sessionMeta(session) };
+                return { stopReason: "end_turn", usage: sessionUsage(session) };
               }
               if ("isReplay" in message && message.isReplay) {
                 // not pending or unrelated replay message
@@ -874,62 +852,45 @@ export class ClaudeAcpAgent implements Agent {
             break;
           }
           case "tool_progress": {
-            // Forward tool execution progress as a tool_call_update so clients
-            // can show elapsed time for long-running tools.
+            // Forward tool execution progress via extNotification so clients can
+            // show elapsed time for long-running tools without polluting tool output.
             const toolCallId = "tool_use_id" in message ? (message as any).tool_use_id : undefined;
             if (toolCallId) {
-              await this.client.sessionUpdate({
+              await this.client.extNotification("_claude/tool-progress", {
                 sessionId: params.sessionId,
-                update: {
-                  sessionUpdate: "tool_call_update",
-                  toolCallId,
-                  status: "running",
-                  content: [{
-                    type: "text",
-                    text: `Tool running (${Math.round((message as any).elapsed_time_seconds ?? 0)}s)...`,
-                  }],
-                },
+                toolCallId,
+                toolName: (message as any).tool_name ?? null,
+                elapsedTimeSeconds: (message as any).elapsed_time_seconds ?? 0,
               });
             }
             break;
           }
           case "tool_use_summary": {
-            // Forward collapsed tool-use summaries as agent message chunks
-            // so clients can display a high-level overview of tool activity.
+            // Forward collapsed tool-use summaries via extNotification so clients
+            // can display a high-level overview of tool activity.
             const summary = "summary" in message ? (message as any).summary : undefined;
             if (summary) {
-              await this.client.sessionUpdate({
+              await this.client.extNotification("_claude/tool-use-summary", {
                 sessionId: params.sessionId,
-                update: {
-                  sessionUpdate: "agent_message_chunk",
-                  content: { type: "text", text: summary },
-                },
+                summary,
               });
             }
             break;
           }
           case "rate_limit_event": {
-            // Forward rate limit info via _meta on a usage_update notification.
-            // This allows clients to detect approaching limits, rejections,
-            // and overage status without parsing error message strings.
+            // Forward rate limit info via extNotification so clients can detect
+            // approaching limits and rejections without parsing error message strings.
             const info = "rate_limit_info" in message ? (message as any).rate_limit_info : undefined;
             if (info) {
-              await this.client.sessionUpdate({
+              await this.client.extNotification("_claude/rate-limit", {
                 sessionId: params.sessionId,
-                _meta: {
-                  rateLimitStatus: info.status ?? "unknown",
-                  rateLimitResetsAt: info.resetsAt ?? null,
-                  rateLimitType: info.rateLimitType ?? null,
-                  rateLimitUtilization: info.utilization ?? null,
-                  overageStatus: info.overageStatus ?? null,
-                  overageDisabledReason: info.overageDisabledReason ?? null,
-                  isUsingOverage: info.isUsingOverage ?? false,
-                },
-                update: {
-                  sessionUpdate: "usage_update",
-                  used: lastAssistantTotalUsage ?? 0,
-                  size: lastContextWindowSize,
-                },
+                status: info.status ?? "unknown",
+                resetsAt: info.resetsAt ?? null,
+                rateLimitType: info.rateLimitType ?? null,
+                utilization: info.utilization ?? null,
+                overageStatus: info.overageStatus ?? null,
+                overageDisabledReason: info.overageDisabledReason ?? null,
+                isUsingOverage: info.isUsingOverage ?? false,
               });
             }
             break;
@@ -1633,8 +1594,6 @@ export class ClaudeAcpAgent implements Agent {
         cachedReadTokens: 0,
         cachedWriteTokens: 0,
       },
-      totalCostUsd: 0,
-      lastTerminalReason: null,
       modes,
       models,
       configOptions,
@@ -1665,18 +1624,6 @@ function sessionUsage(session: Session) {
       session.accumulatedUsage.cachedReadTokens +
       session.accumulatedUsage.cachedWriteTokens,
   };
-}
-
-/** Build _meta for PromptResponse with cost and terminal reason from SDK results */
-function sessionMeta(session: Session): Record<string, unknown> {
-  const meta: Record<string, unknown> = {};
-  if (session.totalCostUsd > 0) {
-    meta.costUsd = session.totalCostUsd;
-  }
-  if (session.lastTerminalReason) {
-    meta.terminalReason = session.lastTerminalReason;
-  }
-  return Object.keys(meta).length > 0 ? meta : {};
 }
 
 function createEnvForGateway(gatewayMeta?: GatewayAuthMeta) {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -116,6 +116,10 @@ type Session = {
   cwd: string;
   settingsManager: SettingsManager;
   accumulatedUsage: AccumulatedUsage;
+  /** Cumulative cost in USD for this session (from SDK result messages) */
+  totalCostUsd: number;
+  /** Terminal reason from the last SDK result (e.g. "blocking_limit", "completed") */
+  lastTerminalReason: string | null;
   modes: SessionModeState;
   models: SessionModelState;
   configOptions: SessionConfigOption[];
@@ -486,6 +490,8 @@ export class ClaudeAcpAgent implements Agent {
       cachedReadTokens: 0,
       cachedWriteTokens: 0,
     };
+    session.totalCostUsd = 0;
+    session.lastTerminalReason = null;
 
     let lastAssistantTotalUsage: number | null = null;
     let lastAssistantModel: string | null = null;
@@ -590,7 +596,11 @@ export class ClaudeAcpAgent implements Agent {
               }
               case "session_state_changed": {
                 if (message.state === "idle") {
-                  return { stopReason, usage: sessionUsage(session) };
+                  return {
+                    stopReason,
+                    usage: sessionUsage(session),
+                    _meta: sessionMeta(session),
+                  };
                 }
                 break;
               }
@@ -602,9 +612,33 @@ export class ClaudeAcpAgent implements Agent {
               case "task_notification":
               case "task_progress":
               case "elicitation_complete":
-              case "api_retry":
-                // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
+              case "api_retry": {
+                // Forward API retry events so clients can observe transient failures,
+                // including the HTTP status code and typed error category.
+                const retryMsg = message as any;
+                this.logger.error(
+                  `API retry: attempt=${retryMsg.attempt}/${retryMsg.max_retries}, ` +
+                  `httpStatus=${retryMsg.error_status}, error=${retryMsg.error}, ` +
+                  `delay=${retryMsg.retry_delay_ms}ms`,
+                );
+                await this.client.sessionUpdate({
+                  sessionId: retryMsg.session_id,
+                  _meta: {
+                    apiRetry: {
+                      httpStatus: retryMsg.error_status ?? null,
+                      errorType: retryMsg.error ?? "unknown",
+                      attempt: retryMsg.attempt ?? 0,
+                      maxRetries: retryMsg.max_retries ?? 0,
+                      retryDelayMs: retryMsg.retry_delay_ms ?? 0,
+                    },
+                  },
+                  update: {
+                    sessionUpdate: "agent_message_chunk",
+                    content: { type: "text", text: "" },
+                  },
+                });
                 break;
+              }
               default:
                 unreachable(message, this.logger);
                 break;
@@ -616,6 +650,10 @@ export class ClaudeAcpAgent implements Agent {
             session.accumulatedUsage.outputTokens += message.usage.output_tokens;
             session.accumulatedUsage.cachedReadTokens += message.usage.cache_read_input_tokens;
             session.accumulatedUsage.cachedWriteTokens += message.usage.cache_creation_input_tokens;
+            session.totalCostUsd = message.total_cost_usd;
+            if ("terminal_reason" in message && message.terminal_reason) {
+              session.lastTerminalReason = message.terminal_reason as string;
+            }
 
             const matchingModelUsage = lastAssistantModel
               ? getMatchingModelUsage(message.modelUsage, lastAssistantModel)
@@ -738,7 +776,7 @@ export class ClaudeAcpAgent implements Agent {
                 handedOff = true;
                 // the current loop stops with end_turn,
                 // the loop of the next prompt continues running
-                return { stopReason: "end_turn", usage: sessionUsage(session) };
+                return { stopReason: "end_turn", usage: sessionUsage(session), _meta: sessionMeta(session) };
               }
               if ("isReplay" in message && message.isReplay) {
                 // not pending or unrelated replay message
@@ -835,11 +873,69 @@ export class ClaudeAcpAgent implements Agent {
             }
             break;
           }
-          case "tool_progress":
-          case "tool_use_summary":
+          case "tool_progress": {
+            // Forward tool execution progress as a tool_call_update so clients
+            // can show elapsed time for long-running tools.
+            const toolCallId = "tool_use_id" in message ? (message as any).tool_use_id : undefined;
+            if (toolCallId) {
+              await this.client.sessionUpdate({
+                sessionId: params.sessionId,
+                update: {
+                  sessionUpdate: "tool_call_update",
+                  toolCallId,
+                  status: "running",
+                  content: [{
+                    type: "text",
+                    text: `Tool running (${Math.round((message as any).elapsed_time_seconds ?? 0)}s)...`,
+                  }],
+                },
+              });
+            }
+            break;
+          }
+          case "tool_use_summary": {
+            // Forward collapsed tool-use summaries as agent message chunks
+            // so clients can display a high-level overview of tool activity.
+            const summary = "summary" in message ? (message as any).summary : undefined;
+            if (summary) {
+              await this.client.sessionUpdate({
+                sessionId: params.sessionId,
+                update: {
+                  sessionUpdate: "agent_message_chunk",
+                  content: { type: "text", text: summary },
+                },
+              });
+            }
+            break;
+          }
+          case "rate_limit_event": {
+            // Forward rate limit info via _meta on a usage_update notification.
+            // This allows clients to detect approaching limits, rejections,
+            // and overage status without parsing error message strings.
+            const info = "rate_limit_info" in message ? (message as any).rate_limit_info : undefined;
+            if (info) {
+              await this.client.sessionUpdate({
+                sessionId: params.sessionId,
+                _meta: {
+                  rateLimitStatus: info.status ?? "unknown",
+                  rateLimitResetsAt: info.resetsAt ?? null,
+                  rateLimitType: info.rateLimitType ?? null,
+                  rateLimitUtilization: info.utilization ?? null,
+                  overageStatus: info.overageStatus ?? null,
+                  overageDisabledReason: info.overageDisabledReason ?? null,
+                  isUsingOverage: info.isUsingOverage ?? false,
+                },
+                update: {
+                  sessionUpdate: "usage_update",
+                  used: lastAssistantTotalUsage ?? 0,
+                  size: lastContextWindowSize,
+                },
+              });
+            }
+            break;
+          }
           case "auth_status":
           case "prompt_suggestion":
-          case "rate_limit_event":
             break;
           default:
             unreachable(message);
@@ -1537,6 +1633,8 @@ export class ClaudeAcpAgent implements Agent {
         cachedReadTokens: 0,
         cachedWriteTokens: 0,
       },
+      totalCostUsd: 0,
+      lastTerminalReason: null,
       modes,
       models,
       configOptions,
@@ -1567,6 +1665,18 @@ function sessionUsage(session: Session) {
       session.accumulatedUsage.cachedReadTokens +
       session.accumulatedUsage.cachedWriteTokens,
   };
+}
+
+/** Build _meta for PromptResponse with cost and terminal reason from SDK results */
+function sessionMeta(session: Session): Record<string, unknown> {
+  const meta: Record<string, unknown> = {};
+  if (session.totalCostUsd > 0) {
+    meta.costUsd = session.totalCostUsd;
+  }
+  if (session.lastTerminalReason) {
+    meta.terminalReason = session.lastTerminalReason;
+  }
+  return Object.keys(meta).length > 0 ? meta : {};
 }
 
 function createEnvForGateway(gatewayMeta?: GatewayAuthMeta) {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -854,11 +854,11 @@ export class ClaudeAcpAgent implements Agent {
           case "tool_progress": {
             // Forward tool execution progress via extNotification so clients can
             // show elapsed time for long-running tools without polluting tool output.
-            const toolCallId = "tool_use_id" in message ? (message as any).tool_use_id : undefined;
-            if (toolCallId) {
+            const toolUseId = "tool_use_id" in message ? (message as any).tool_use_id : undefined;
+            if (toolUseId) {
               await this.client.extNotification("_claude/tool-progress", {
                 sessionId: params.sessionId,
-                toolCallId,
+                toolUseId,
                 toolName: (message as any).tool_name ?? null,
                 elapsedTimeSeconds: (message as any).elapsed_time_seconds ?? 0,
               });
@@ -873,6 +873,10 @@ export class ClaudeAcpAgent implements Agent {
               await this.client.extNotification("_claude/tool-use-summary", {
                 sessionId: params.sessionId,
                 summary,
+                precedingToolUseIds:
+                  "preceding_tool_use_ids" in message
+                    ? (message as any).preceding_tool_use_ids ?? []
+                    : [],
               });
             }
             break;
@@ -891,6 +895,7 @@ export class ClaudeAcpAgent implements Agent {
                 overageStatus: info.overageStatus ?? null,
                 overageDisabledReason: info.overageDisabledReason ?? null,
                 isUsingOverage: info.isUsingOverage ?? false,
+                surpassedThreshold: info.surpassedThreshold ?? null,
               });
             }
             break;

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1337,8 +1337,7 @@ describe("stop reason propagation", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
-      totalCostUsd: 0,
-      lastTerminalReason: null,
+
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1478,8 +1477,7 @@ describe("stop reason propagation", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
-      totalCostUsd: 0,
-      lastTerminalReason: null,
+
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1553,8 +1551,7 @@ describe("session/close", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
-      totalCostUsd: 0,
-      lastTerminalReason: null,
+
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1725,8 +1722,7 @@ describe("usage_update computation", () => {
         availableModels: [],
       },
       settingsManager: {} as any,
-      totalCostUsd: 0,
-      lastTerminalReason: null,
+
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1337,6 +1337,8 @@ describe("stop reason propagation", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
+      totalCostUsd: 0,
+      lastTerminalReason: null,
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1476,6 +1478,8 @@ describe("stop reason propagation", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
+      totalCostUsd: 0,
+      lastTerminalReason: null,
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1549,6 +1553,8 @@ describe("session/close", () => {
         availableModels: [],
       },
       settingsManager: { dispose: vi.fn() } as any,
+      totalCostUsd: 0,
+      lastTerminalReason: null,
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -1719,6 +1725,8 @@ describe("usage_update computation", () => {
         availableModels: [],
       },
       settingsManager: {} as any,
+      totalCostUsd: 0,
+      lastTerminalReason: null,
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,


### PR DESCRIPTION
## Summary

The claude-agent-acp runtime currently drops several Claude Agent SDK messages on the floor: `api_retry`, `tool_progress`, `tool_use_summary`, and `rate_limit_event`. ACP clients can't see that the SDK is retrying a 529, that a long-running tool is making progress, that the model summarized prior tool uses, or that a Claude.ai web-session rate limit fired.

This PR forwards those four events to clients via typed `_claude/`-namespaced `extNotification` calls, so clients that care can surface them without touching the transport.

## What's forwarded

All four events are forwarded via `this.client.extNotification("_claude/<name>", { sessionId, ...fields })`:

1. **`_claude/api-retry`** — fired when the SDK retries a transient API error (overload, rate limit response, etc.)
   - `httpStatus`, `errorType`, `attempt`, `maxRetries`, `retryDelayMs`

2. **`_claude/tool-progress`** — periodic heartbeat from a long-running tool
   - `toolUseId`, `toolName`, `elapsedTimeSeconds`

3. **`_claude/tool-use-summary`** — model-generated summary of a group of prior tool uses
   - `summary`, `precedingToolUseIds`

4. **`_claude/rate-limit`** — Claude.ai web-session rate limit state change
   - `status`, `resetsAt`, `rateLimitType`, `utilization`, `overageStatus`, `overageDisabledReason`, `isUsingOverage`, `surpassedThreshold`

## Why `extNotification`

Per reviewer feedback, these aren't first-class ACP session updates (the spec doesn't define them), so forwarding them as `sessionUpdate` entries would pollute the standard update stream. `extNotification` with a `_claude/` prefix is the documented escape hatch for vendor-specific events, keeps the core ACP surface clean, and lets clients opt in by listening on the namespaced method.

## Other changes

- **Fall-through bug fix**: the previous switch had `hook_progress`, `hook_response`, `files_persisted`, `task_started`, `task_notification`, `task_progress`, and `elicitation_complete` falling through into the newly-added `api_retry` handler. Each now has its own explicit `break`.
- **Dropped `sessionMeta()` / `_meta` additions** from earlier revisions — no longer needed once events are forwarded directly to the client as they happen.
- Logs `api_retry` at error level (same as before) so the CLI still shows retries in the terminal.

## Field naming

Field names match the fazm ACP client's existing shape (`toolUseId`, `httpStatus`, `retryDelayMs`, `precedingToolUseIds`, etc.) so a client already consuming these from a monkey-patched bridge can swap over without changing its handler code.

## Testing

- `npm run build` — clean
- `npm test` — all existing tests pass; mock Session objects updated to drop the removed `totalCostUsd` / `lastTerminalReason` fields
