### PR TITLE
Surface rate_limit_event quota metadata

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -94,6 +94,42 @@ function sanitizeTitle(text: string): string {
   return sanitized.slice(0, MAX_TITLE_LENGTH - 1) + "…";
 }
 
+function normalizeRateLimitWindowType(rateLimitType?: string): "FIVE_HOUR" | "WEEKLY" {
+  switch (rateLimitType) {
+    case "seven_day":
+    case "seven_day_opus":
+    case "seven_day_sonnet":
+      return "WEEKLY";
+    default:
+      return "FIVE_HOUR";
+  }
+}
+
+function toQuotaSessionNotification(
+  sessionId: string,
+  rateLimitInfo: { rateLimitType?: string; resetsAt?: number; utilization?: number },
+): SessionNotification {
+  return {
+    sessionId,
+    _meta: {
+      codor: {
+        kind: "quota",
+        window: normalizeRateLimitWindowType(rateLimitInfo.rateLimitType),
+        limitedUntil:
+          typeof rateLimitInfo.resetsAt === "number"
+            ? new Date(rateLimitInfo.resetsAt * 1000).toISOString()
+            : new Date().toISOString(),
+        utilization: rateLimitInfo.utilization ?? 0,
+      },
+    },
+    update: {
+      sessionUpdate: "usage_update",
+      size: 0,
+      used: 0,
+    },
+  };
+}
+
 /**
  * Logger interface for customizing logging output
  */
@@ -884,6 +920,11 @@ export class ClaudeAcpAgent implements Agent {
           case "auth_status":
           case "prompt_suggestion":
           case "rate_limit_event":
+            if (message.type === "rate_limit_event") {
+              await this.client.sessionUpdate(
+                toQuotaSessionNotification(params.sessionId, message.rate_limit_info),
+              );
+            }
             break;
           default:
             unreachable(message);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -112,7 +112,7 @@ function toQuotaSessionNotification(
   return {
     sessionId,
     _meta: {
-      codor: {
+      claude: {
         kind: "quota",
         window: normalizeRateLimitWindowType(rateLimitInfo.rateLimitType),
         limitedUntil:

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1909,6 +1909,70 @@ describe("usage_update computation", () => {
     expect(usageUpdate.update.used).toBe(1800);
   });
 
+  it("emits codor quota metadata for rate_limit_event messages", async () => {
+    const { agent, updates } = createMockAgentWithCapture();
+    const resetsAt = Math.floor(Date.now() / 1000) + 3600;
+    const resetAtIso = new Date(resetsAt * 1000).toISOString();
+
+    injectSession(agent, [
+      {
+        type: "rate_limit_event" as const,
+        rate_limit_info: {
+          status: "allowed_warning" as const,
+          resetsAt,
+          rateLimitType: "five_hour" as const,
+          utilization: 0.85,
+        },
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      {
+        type: "result" as const,
+        subtype: "success" as const,
+        stop_reason: null,
+        is_error: false,
+        result: "",
+        errors: [],
+        duration_ms: 0,
+        duration_api_ms: 0,
+        num_turns: 1,
+        total_cost_usd: 0,
+        usage: {
+          input_tokens: 10,
+          output_tokens: 5,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+        modelUsage: {},
+        permission_denials: [],
+        uuid: randomUUID(),
+        session_id: "test-session",
+      },
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    const quotaUpdate = updates.find(
+      (u: any) => u._meta?.codor?.kind === "quota" && u.update?.sessionUpdate === "usage_update",
+    );
+    expect(quotaUpdate).toBeDefined();
+    expect(quotaUpdate._meta.codor).toMatchObject({
+      kind: "quota",
+      window: "FIVE_HOUR",
+      limitedUntil: resetAtIso,
+      utilization: 0.85,
+    });
+    expect(quotaUpdate.update).toMatchObject({
+      sessionUpdate: "usage_update",
+      size: 0,
+      used: 0,
+    });
+  });
+
   it("size reflects the current model's context window, not min across all", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     injectSession(agent, [

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1909,7 +1909,7 @@ describe("usage_update computation", () => {
     expect(usageUpdate.update.used).toBe(1800);
   });
 
-  it("emits codor quota metadata for rate_limit_event messages", async () => {
+  it("emits claude quota metadata for rate_limit_event messages", async () => {
     const { agent, updates } = createMockAgentWithCapture();
     const resetsAt = Math.floor(Date.now() / 1000) + 3600;
     const resetAtIso = new Date(resetsAt * 1000).toISOString();
@@ -1957,10 +1957,10 @@ describe("usage_update computation", () => {
     });
 
     const quotaUpdate = updates.find(
-      (u: any) => u._meta?.codor?.kind === "quota" && u.update?.sessionUpdate === "usage_update",
+      (u: any) => u._meta?.claude?.kind === "quota" && u.update?.sessionUpdate === "usage_update",
     );
     expect(quotaUpdate).toBeDefined();
-    expect(quotaUpdate._meta.codor).toMatchObject({
+    expect(quotaUpdate._meta.claude).toMatchObject({
       kind: "quota",
       window: "FIVE_HOUR",
       limitedUntil: resetAtIso,


### PR DESCRIPTION
Emit a quota _meta payload for rate_limit_event so ACP clients can track rate limits without parsing SDK-specific stream messages. This keeps the change isolated to ACP session updates.