### PR TITLE
Add CLAUDE_CODE_WRAPPER_MODE environment variable support for enterprises using Claude Code wrappers that handle authentication internally

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,16 @@ Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
 
 Override the Claude Code executable used by the ACP agent. By default, the agent uses the CLI bundled with `@anthropic-ai/claude-agent-sdk`. Set this variable to point to a custom Claude Code installation.
 
-When set without `CLAUDE_CODE_WRAPPER_MODE`, the agent still uses the standard ACP authentication flow (Claude Subscription / Anthropic Console / Gateway).
+When set without `CLAUDE_CODE_CUSTOM_AUTH`, the agent still uses the standard ACP authentication flow (Claude Subscription / Anthropic Console / Gateway).
 
-### `CLAUDE_CODE_WRAPPER_MODE`
+### `CLAUDE_CODE_CUSTOM_AUTH`
 
 Enable wrapper mode for use with Claude Code wrappers that handle authentication internally (e.g. enterprise SSO, API gateway). When enabled:
 
 - All ACP-level authentication prompts are skipped
 - The wrapper is expected to provide its own authentication
 
-**Requires `CLAUDE_CODE_EXECUTABLE` to be set.** The agent will throw an error on startup if `CLAUDE_CODE_WRAPPER_MODE` is set without `CLAUDE_CODE_EXECUTABLE`.
+**Requires `CLAUDE_CODE_EXECUTABLE` to be set.** The agent will throw an error on startup if `CLAUDE_CODE_CUSTOM_AUTH` is set without `CLAUDE_CODE_EXECUTABLE`.
 
 ## Contribution Policy
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,23 @@ This tool implements an ACP agent by using the official [Claude Agent SDK](https
 
 Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
 
+## Environment Variables
+
+### `CLAUDE_CODE_EXECUTABLE`
+
+Override the Claude Code executable used by the ACP agent. By default, the agent uses the CLI bundled with `@anthropic-ai/claude-agent-sdk`. Set this variable to point to a custom Claude Code installation.
+
+When set without `CLAUDE_CODE_WRAPPER_MODE`, the agent still uses the standard ACP authentication flow (Claude Subscription / Anthropic Console / Gateway).
+
+### `CLAUDE_CODE_WRAPPER_MODE`
+
+Enable wrapper mode for use with Claude Code wrappers that handle authentication internally (e.g. enterprise SSO, API gateway). When enabled:
+
+- All ACP-level authentication prompts are skipped
+- The wrapper is expected to provide its own authentication
+
+**Requires `CLAUDE_CODE_EXECUTABLE` to be set.** The agent will throw an error on startup if `CLAUDE_CODE_WRAPPER_MODE` is set without `CLAUDE_CODE_EXECUTABLE`.
+
 ## Contribution Policy
 
 This project does not require a Contributor License Agreement (CLA). Instead, contributions are accepted under the following terms:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ Enable wrapper mode for use with Claude Code wrappers that handle authentication
 
 **Requires `CLAUDE_CODE_EXECUTABLE` to be set.** The agent will throw an error on startup if `CLAUDE_CODE_CUSTOM_AUTH` is set without `CLAUDE_CODE_EXECUTABLE`.
 
+```bash                                                                                                                                                    
+CLAUDE_CODE_CUSTOM_AUTH=1                                                                                                                                
+CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude                                                                                                               
+```
+
 ## Contribution Policy
 
 This project does not require a Contributor License Agreement (CLA). Instead, contributions are accepted under the following terms:

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -240,6 +240,21 @@ function shouldHideClaudeAuth(): boolean {
   return process.argv.includes("--hide-claude-auth");
 }
 
+function shouldUseWrapperMode(): boolean {
+  if (process.env.CLAUDE_CODE_WRAPPER_MODE) {
+    if (!process.env.CLAUDE_CODE_EXECUTABLE) {
+      throw new Error(
+        "CLAUDE_CODE_WRAPPER_MODE requires CLAUDE_CODE_EXECUTABLE to be set. " +
+        "Please configure CLAUDE_CODE_EXECUTABLE to point to your Claude Code wrapper executable " +
+        "that handles authentication internally (e.g. enterprise SSO, API gateway). " +
+        "Wrapper mode bypasses all ACP-level authentication, so the wrapper must provide its own.",
+      );
+    }
+    return true;
+  }
+  return false;
+}
+
 // Bypass Permissions doesn't work if we are a root/sudo user
 const IS_ROOT = (process.geteuid?.() ?? process.getuid?.()) === 0;
 const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
@@ -425,12 +440,15 @@ export class ClaudeAcpAgent implements Agent {
         title: "Claude Agent",
         version: packageJson.version,
       },
-      authMethods: [...terminalAuthMethods, ...(supportsGatewayAuth ? [gatewayAuthMethod] : [])],
+      authMethods: shouldUseWrapperMode()
+        ? []
+        : [...terminalAuthMethods, ...(supportsGatewayAuth ? [gatewayAuthMethod] : [])],
     };
   }
 
   async newSession(params: NewSessionRequest): Promise<NewSessionResponse> {
     if (
+      !shouldUseWrapperMode() &&
       !this.gatewayAuthMeta &&
       fs.existsSync(path.resolve(os.homedir(), ".claude.json.backup")) &&
       !fs.existsSync(path.resolve(os.homedir(), ".claude.json"))
@@ -1533,6 +1551,7 @@ export class ClaudeAcpAgent implements Agent {
 
     if (
       shouldHideClaudeAuth() &&
+      !shouldUseWrapperMode() &&
       initializationResult.account.subscriptionType &&
       !this.gatewayAuthMeta
     ) {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -241,10 +241,10 @@ function shouldHideClaudeAuth(): boolean {
 }
 
 function shouldUseWrapperMode(): boolean {
-  if (process.env.CLAUDE_CODE_WRAPPER_MODE) {
+  if (process.env.CLAUDE_CODE_CUSTOM_AUTH) {
     if (!process.env.CLAUDE_CODE_EXECUTABLE) {
       throw new Error(
-        "CLAUDE_CODE_WRAPPER_MODE requires CLAUDE_CODE_EXECUTABLE to be set. " +
+        "CLAUDE_CODE_CUSTOM_AUTH requires CLAUDE_CODE_EXECUTABLE to be set. " +
         "Please configure CLAUDE_CODE_EXECUTABLE to point to your Claude Code wrapper executable " +
         "that handles authentication internally (e.g. enterprise SSO, API gateway). " +
         "Wrapper mode bypasses all ACP-level authentication, so the wrapper must provide its own.",


### PR DESCRIPTION
 Add CLAUDE_CODE_WRAPPER_MODE environment variable support for enterprises using Claude Code wrappers that handle authentication internally (e.g. enterprise SSO, API gateway). When enabled, all ACP-level auth prompts are skipped and the configured CLAUDE_CODE_EXECUTABLE is used directly.

CLAUDE_CODE_WRAPPER_MODE requires CLAUDE_CODE_EXECUTABLE to be set, and throws a descriptive error if misconfigured.