### PR TITLE
fix: Remove dot from auto mode description

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1654,7 +1654,7 @@ export class ClaudeAcpAgent implements Agent {
       {
         id: "auto",
         name: "Auto",
-        description: "Use a model classifier to approve/deny permission prompts.",
+        description: "Use a model classifier to approve/deny permission prompts",
       },
       {
         id: "default",


### PR DESCRIPTION
The other descriptions do not end with dot.