### PR TITLE
feat: add Usage config dropdown for context and rate-limit visibility

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -54,6 +54,7 @@ import {
   Query,
   query,
   SDKPartialAssistantMessage,
+  SDKRateLimitInfo,
   SDKUserMessage,
   SlashCommand,
 } from "@anthropic-ai/claude-agent-sdk";
@@ -73,6 +74,7 @@ import {
   toolUpdateFromEditToolResponse,
   toolUpdateFromToolResult,
 } from "./tools.js";
+import { buildUsageConfigOption, UsageRateLimitKey, UsageView } from "./usage.js";
 import { nodeToWebReadable, nodeToWebWritable, Pushable, unreachable } from "./utils.js";
 
 export const CLAUDE_CONFIG_DIR =
@@ -147,6 +149,14 @@ type Session = {
    *  DEFAULT_CONTEXT_WINDOW, refreshed from each result's modelUsage, and
    *  invalidated when the user switches the session's model. */
   contextWindowSize: number;
+  /** Which metric the "Usage" dropdown is currently displaying. */
+  usageView: UsageView;
+  /** Latest context tokens used (total) and window size, used to render the
+   *  `Ctx:` view. Null until the first assistant message reports usage. */
+  usageContext: { used: number; size: number } | null;
+  /** Latest rate-limit info keyed by `rateLimitType`. Updated from
+   *  `rate_limit_event` SDK messages. */
+  usageRateLimits: Partial<Record<UsageRateLimitKey, SDKRateLimitInfo>>;
 };
 
 /** Compute a stable fingerprint of the session-defining params so we can
@@ -735,6 +745,11 @@ export class ClaudeAcpAgent implements Agent {
                   },
                 },
               });
+              session.usageContext = {
+                used: lastAssistantTotalUsage,
+                size: session.contextWindowSize,
+              };
+              await this.pushUsageOption(params.sessionId);
             }
 
             if (session.cancelled) {
@@ -975,8 +990,21 @@ export class ClaudeAcpAgent implements Agent {
           case "tool_use_summary":
           case "auth_status":
           case "prompt_suggestion":
-          case "rate_limit_event":
             break;
+          case "rate_limit_event": {
+            const info = message.rate_limit_info;
+            const key = info.rateLimitType;
+            if (
+              key === "five_hour" ||
+              key === "seven_day_opus" ||
+              key === "seven_day_sonnet" ||
+              key === "seven_day"
+            ) {
+              session.usageRateLimits = { ...session.usageRateLimits, [key]: info };
+              await this.pushUsageOption(params.sessionId);
+            }
+            break;
+          }
           default:
             unreachable(message);
             break;
@@ -1407,7 +1435,32 @@ export class ClaudeAcpAgent implements Agent {
         session.contextWindowSize = inferContextWindowFromModel(value) ?? DEFAULT_CONTEXT_WINDOW;
       }
       session.models = { ...session.models, currentModelId: value };
+    } else if (configId === "usage") {
+      if (value === "context" || value === "five_hour" || value === "week") {
+        session.usageView = value;
+      }
     }
+  }
+
+  /** Rebuild the `usage` config option from current session state and send a
+   *  `config_option_update` notification. Called on every SDK event that
+   *  changes usage data (`rate_limit_event`, `result`). */
+  private async pushUsageOption(sessionId: string): Promise<void> {
+    const session = this.sessions[sessionId];
+    if (!session) return;
+    const usageOption = buildUsageConfigOption(
+      session.usageView,
+      session.usageContext,
+      session.usageRateLimits,
+    );
+    session.configOptions = session.configOptions.map((o) => (o.id === "usage" ? usageOption : o));
+    await this.client.sessionUpdate({
+      sessionId,
+      update: {
+        sessionUpdate: "config_option_update",
+        configOptions: session.configOptions,
+      },
+    });
   }
 
   private async getOrCreateSession(params: {
@@ -1691,7 +1744,12 @@ export class ClaudeAcpAgent implements Agent {
       availableModes,
     };
 
-    const configOptions = buildConfigOptions(modes, models);
+    const initialUsageState = {
+      view: "context" as UsageView,
+      context: null,
+      rateLimits: {},
+    };
+    const configOptions = buildConfigOptions(modes, models, initialUsageState);
 
     this.sessions[sessionId] = {
       query: q,
@@ -1716,6 +1774,9 @@ export class ClaudeAcpAgent implements Agent {
       emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
       contextWindowSize:
         inferContextWindowFromModel(models.currentModelId) ?? DEFAULT_CONTEXT_WINDOW,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
 
     return {
@@ -1803,8 +1864,13 @@ function createEnvForGateway(gatewayMeta?: GatewayAuthMeta) {
 function buildConfigOptions(
   modes: SessionModeState,
   models: SessionModelState,
+  usage?: {
+    view: UsageView;
+    context: { used: number; size: number } | null;
+    rateLimits: Partial<Record<UsageRateLimitKey, SDKRateLimitInfo>>;
+  },
 ): SessionConfigOption[] {
-  return [
+  const options: SessionConfigOption[] = [
     {
       id: "mode",
       name: "Mode",
@@ -1832,6 +1898,10 @@ function buildConfigOptions(
       })),
     },
   ];
+  if (usage) {
+    options.push(buildUsageConfigOption(usage.view, usage.context, usage.rateLimits));
+  }
+  return options;
 }
 
 // Claude Code CLI persists display strings like "opus[1m]" in settings,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1351,6 +1351,9 @@ describe("stop reason propagation", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
   }
 
@@ -1493,6 +1496,9 @@ describe("stop reason propagation", () => {
       nextPendingOrder: 0,
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
 
     const response = await agent.prompt({
@@ -1527,6 +1533,236 @@ describe("stop reason propagation", () => {
         prompt: [{ type: "text", text: "test" }],
       }),
     ).rejects.toThrow("Internal error");
+  });
+});
+
+describe("Usage config_option_update push from SDK messages", () => {
+  function createAgentWithCapture() {
+    const updates: SessionNotification[] = [];
+    const mockClient = {
+      sessionUpdate: async (n: SessionNotification) => {
+        updates.push(n);
+      },
+    } as unknown as AgentSideConnection;
+    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+    return { agent, updates };
+  }
+
+  function injectSession(agent: ClaudeAcpAgent, messages: any[]) {
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage, done } = await iter.next();
+      if (!done && userMessage) {
+        yield {
+          type: "user",
+          message: userMessage.message,
+          parent_tool_use_id: null,
+          uuid: userMessage.uuid,
+          session_id: "test-session",
+          isReplay: true,
+        };
+      }
+      yield* messages;
+    }
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [
+        {
+          id: "usage",
+          name: "Usage",
+          type: "select",
+          currentValue: "context",
+          options: [],
+        } as any,
+      ],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+      abortController: new AbortController(),
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
+    };
+  }
+
+  function idleMessage() {
+    return { type: "system", subtype: "session_state_changed", state: "idle" };
+  }
+
+  function resultMessage(overrides: Partial<{ total_cost_usd: number }> = {}) {
+    return {
+      type: "result" as const,
+      subtype: "success",
+      stop_reason: "end_turn",
+      is_error: false,
+      result: "",
+      errors: [],
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 1,
+      total_cost_usd: overrides.total_cost_usd ?? 0,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+  }
+
+  function rateLimitEvent(info: {
+    rateLimitType: string;
+    utilization?: number;
+    resetsAt?: number;
+    status?: "allowed" | "allowed_warning" | "rejected";
+  }) {
+    return {
+      type: "rate_limit_event" as const,
+      rate_limit_info: {
+        status: info.status ?? "allowed_warning",
+        rateLimitType: info.rateLimitType,
+        utilization: info.utilization,
+        resetsAt: info.resetsAt,
+      },
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+  }
+
+  it("rate_limit_event with five_hour updates state and pushes config_option_update", async () => {
+    const { agent, updates } = createAgentWithCapture();
+    const nowS = Math.floor(Date.now() / 1000);
+    injectSession(agent, [
+      rateLimitEvent({
+        rateLimitType: "five_hour",
+        utilization: 0.62,
+        resetsAt: nowS + 2 * 3600,
+      }),
+      resultMessage(),
+      idleMessage(),
+    ]);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(agent.sessions["test-session"]!.usageRateLimits.five_hour).toEqual(
+      expect.objectContaining({ rateLimitType: "five_hour", utilization: 0.62 }),
+    );
+
+    const usagePushes = updates.filter(
+      (n) =>
+        "update" in n &&
+        (n.update as { sessionUpdate: string }).sessionUpdate === "config_option_update",
+    );
+    expect(usagePushes.length).toBeGreaterThan(0);
+
+    const push = usagePushes[0].update as { configOptions: any[] };
+    const usageOption = push.configOptions.find((o) => o.id === "usage");
+    expect(usageOption).toBeDefined();
+    expect(usageOption.options.some((o: { value: string }) => o.value === "five_hour")).toBe(true);
+    const fiveHour = usageOption.options.find((o: { value: string }) => o.value === "five_hour");
+    expect(fiveHour.name).toContain("5h");
+    expect(fiveHour.name).toContain("62%");
+  });
+
+  it("rate_limit_event with unhandled type (overage) is ignored", async () => {
+    const { agent, updates } = createAgentWithCapture();
+    injectSession(agent, [
+      rateLimitEvent({ rateLimitType: "overage", utilization: 0.5 }),
+      resultMessage(),
+      idleMessage(),
+    ]);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(agent.sessions["test-session"]!.usageRateLimits).toEqual({});
+    const fiveHourPushes = updates.filter((n) => {
+      if (!("update" in n)) return false;
+      const u = n.update as { sessionUpdate: string; configOptions?: any[] };
+      if (u.sessionUpdate !== "config_option_update") return false;
+      const opt = u.configOptions?.find((o) => o.id === "usage");
+      return opt?.options?.some((o: { value: string }) => o.value === "five_hour");
+    });
+    expect(fiveHourPushes).toHaveLength(0);
+  });
+
+  it("rate_limit_event with seven_day_opus stores opus bucket and pushes week option", async () => {
+    const { agent, updates } = createAgentWithCapture();
+    injectSession(agent, [
+      rateLimitEvent({ rateLimitType: "seven_day_opus", utilization: 0.18 }),
+      resultMessage(),
+      idleMessage(),
+    ]);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(agent.sessions["test-session"]!.usageRateLimits.seven_day_opus).toBeDefined();
+
+    const weekPush = updates.find((n) => {
+      if (!("update" in n)) return false;
+      const u = n.update as { sessionUpdate: string; configOptions?: any[] };
+      if (u.sessionUpdate !== "config_option_update") return false;
+      const opt = u.configOptions?.find((o) => o.id === "usage");
+      return opt?.options?.some((o: { value: string }) => o.value === "week");
+    });
+    expect(weekPush).toBeDefined();
+  });
+
+  it("every rate_limit_event produces its own config_option_update push", async () => {
+    const { agent, updates } = createAgentWithCapture();
+    injectSession(agent, [
+      rateLimitEvent({ rateLimitType: "five_hour", utilization: 0.4 }),
+      rateLimitEvent({ rateLimitType: "seven_day_opus", utilization: 0.18 }),
+      resultMessage(),
+      idleMessage(),
+    ]);
+
+    await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    const usagePushes = updates.filter((n) => {
+      if (!("update" in n)) return false;
+      return (n.update as { sessionUpdate: string }).sessionUpdate === "config_option_update";
+    });
+    // Two rate_limit_events each trigger a push; the result message adds
+    // no push here because no stream events ran to populate lastAssistantTotalUsage.
+    expect(usagePushes).toHaveLength(2);
+
+    const last = usagePushes[usagePushes.length - 1].update as { configOptions: any[] };
+    const usageOption = last.configOptions.find((o) => o.id === "usage");
+    const values = usageOption.options.map((o: { value: string }) => o.value);
+    expect(values).toContain("five_hour");
+    expect(values).toContain("week");
   });
 });
 
@@ -1569,6 +1805,9 @@ describe("session/close", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
     return agent.sessions[sessionId]!;
   }
@@ -1664,6 +1903,9 @@ describe("getOrCreateSession param change detection", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
     return agent.sessions[sessionId]!;
   }
@@ -1897,6 +2139,9 @@ describe("usage_update computation", () => {
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
   }
 
@@ -2785,6 +3030,9 @@ describe("emitRawSDKMessages", () => {
       abortController: new AbortController(),
       emitRawSDKMessages,
       contextWindowSize: 200000,
+      usageView: "context",
+      usageContext: null,
+      usageRateLimits: {},
     };
   }
 

--- a/src/tests/usage.test.ts
+++ b/src/tests/usage.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk";
+import {
+  buildUsageConfigOption,
+  formatContextUsage,
+  formatFiveHour,
+  formatResetAt,
+  formatResetIn,
+  formatTokens,
+  formatWeek,
+} from "../usage.js";
+
+// All time-based helpers are tested against a fixed wall clock to keep
+// outputs deterministic regardless of when the suite runs.
+const NOW_MS = Date.UTC(2026, 3, 18, 12, 0, 0); // 2026-04-18T12:00:00Z
+const NOW_S = Math.floor(NOW_MS / 1000);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW_MS));
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("formatContextUsage", () => {
+  it("returns placeholder when context is null", () => {
+    expect(formatContextUsage(null)).toEqual({
+      label: "Ctx: —",
+      tooltip: "Context usage not yet available.",
+    });
+  });
+
+  it("returns placeholder when size is 0", () => {
+    expect(formatContextUsage({ used: 100, size: 0 })).toEqual({
+      label: "Ctx: —",
+      tooltip: "Context usage not yet available.",
+    });
+  });
+
+  it("formats a typical percentage", () => {
+    expect(formatContextUsage({ used: 45_000, size: 200_000 })).toEqual({
+      label: "Ctx: 23%",
+      tooltip: "Context: 45k / 200k tokens (23%)",
+    });
+  });
+
+  it("rounds to the nearest whole percent", () => {
+    // 92_345 / 200_000 = 46.1725% → rounds to 46%
+    expect(formatContextUsage({ used: 92_345, size: 200_000 }).label).toBe("Ctx: 46%");
+  });
+
+  it("handles over-limit usage without clamping", () => {
+    expect(formatContextUsage({ used: 250_000, size: 200_000 }).label).toBe("Ctx: 125%");
+  });
+
+  it("uses M suffix for >=1M contexts", () => {
+    const res = formatContextUsage({ used: 500_000, size: 1_000_000 });
+    expect(res.tooltip).toBe("Context: 500k / 1.00M tokens (50%)");
+  });
+});
+
+describe("formatTokens", () => {
+  it("returns raw number for <1k", () => {
+    expect(formatTokens(0)).toBe("0");
+    expect(formatTokens(999)).toBe("999");
+  });
+
+  it("returns k-scaled string for 1k-999k", () => {
+    expect(formatTokens(1_000)).toBe("1k");
+    expect(formatTokens(45_678)).toBe("46k");
+    expect(formatTokens(999_999)).toBe("1000k");
+  });
+
+  it("returns M-scaled string with 2 decimals for >=1M", () => {
+    expect(formatTokens(1_000_000)).toBe("1.00M");
+    expect(formatTokens(1_234_567)).toBe("1.23M");
+  });
+});
+
+describe("formatResetIn", () => {
+  it("returns null when resetsAt is undefined", () => {
+    expect(formatResetIn(undefined)).toBeNull();
+  });
+
+  it("returns null when resetsAt is in the past", () => {
+    expect(formatResetIn(NOW_S - 60)).toBeNull();
+  });
+
+  it("returns null when resetsAt is exactly now", () => {
+    expect(formatResetIn(NOW_S)).toBeNull();
+  });
+
+  it("formats a future reset as H:MM", () => {
+    // 2h 15m in the future
+    expect(formatResetIn(NOW_S + 2 * 3600 + 15 * 60)).toBe("2:15");
+  });
+
+  it("pads single-digit minutes", () => {
+    expect(formatResetIn(NOW_S + 3600 + 5 * 60)).toBe("1:05");
+  });
+
+  it("handles large hour counts (no cap)", () => {
+    expect(formatResetIn(NOW_S + 25 * 3600 + 30 * 60)).toBe("25:30");
+  });
+
+  it("rounds down to the minute", () => {
+    // 1h 0m 59s → floor to 1:00
+    expect(formatResetIn(NOW_S + 3600 + 59)).toBe("1:00");
+  });
+});
+
+describe("formatResetAt", () => {
+  it("returns null when resetsAt is undefined", () => {
+    expect(formatResetAt(undefined)).toBeNull();
+  });
+
+  it("includes a timezone name for same-day resets", () => {
+    const result = formatResetAt(NOW_S + 3 * 3600);
+    expect(result).not.toBeNull();
+    // The exact local-time formatting varies by host TZ, but the short
+    // timezone name should always appear (e.g. "UTC", "EDT", "PST", …).
+    expect(result).toMatch(/[A-Z]{2,5}/);
+  });
+
+  it("includes weekday+month+day for cross-day resets", () => {
+    // 3 days later
+    const result = formatResetAt(NOW_S + 3 * 86400);
+    expect(result).not.toBeNull();
+    // Expect a weekday abbreviation (Mon, Tue, …) followed by a month
+    // abbreviation and day-of-month.
+    expect(result).toMatch(/^[A-Za-z]{3}, [A-Za-z]{3} \d+/);
+  });
+});
+
+describe("formatFiveHour", () => {
+  it("returns null when info is undefined", () => {
+    expect(formatFiveHour(undefined)).toBeNull();
+  });
+
+  it("returns null when neither utilization nor resetsAt are present", () => {
+    expect(formatFiveHour({ status: "allowed" })).toBeNull();
+  });
+
+  it("returns null when resetsAt is in the past and utilization is missing", () => {
+    expect(formatFiveHour({ status: "allowed", resetsAt: NOW_S - 60 })).toBeNull();
+  });
+
+  it("shows utilization only when resetsAt is missing", () => {
+    const result = formatFiveHour({ status: "allowed", utilization: 0.62 });
+    expect(result).not.toBeNull();
+    expect(result!.label).toBe("5h 62%");
+    expect(result!.tooltip).toBe("5-hour limit: 62% used");
+  });
+
+  it("shows time-until only when utilization is missing", () => {
+    const result = formatFiveHour({ status: "allowed", resetsAt: NOW_S + 2 * 3600 + 15 * 60 });
+    expect(result).not.toBeNull();
+    expect(result!.label).toBe("5h 2:15");
+    // Tooltip still explains that utilization is unknown before the threshold.
+    expect(result!.tooltip).toContain("usage unknown until threshold");
+    expect(result!.tooltip).toContain("resets at");
+  });
+
+  it("shows both utilization and time-until when available", () => {
+    const result = formatFiveHour({
+      status: "allowed",
+      utilization: 0.62,
+      resetsAt: NOW_S + 2 * 3600 + 15 * 60,
+    });
+    expect(result).not.toBeNull();
+    expect(result!.label).toBe("5h 62% 2:15");
+    expect(result!.tooltip).toContain("5-hour limit: 62% used");
+    expect(result!.tooltip).toContain("resets at");
+  });
+
+  it("appends approaching-limit status to tooltip", () => {
+    const result = formatFiveHour({ status: "allowed_warning", utilization: 0.85 });
+    expect(result!.tooltip).toContain("status: approaching limit");
+  });
+
+  it("appends limit-reached status to tooltip", () => {
+    const result = formatFiveHour({ status: "rejected", utilization: 1.0 });
+    expect(result!.tooltip).toContain("status: limit reached");
+  });
+});
+
+describe("formatWeek", () => {
+  const baseInfo = (u: number): SDKRateLimitInfo => ({
+    status: "allowed",
+    utilization: u,
+    resetsAt: NOW_S + 3 * 86400,
+  });
+
+  it("returns null when no weekly info is present", () => {
+    expect(formatWeek(undefined, undefined, undefined)).toBeNull();
+  });
+
+  it("returns null when primary info has no utilization", () => {
+    // Weekly data arrives only once a warning threshold is crossed — the
+    // SDK emits resetsAt alone in normal state, which we should hide.
+    expect(
+      formatWeek({ status: "allowed", resetsAt: NOW_S + 86400 }, undefined, undefined),
+    ).toBeNull();
+  });
+
+  it("formats opus utilization as label with Opus in tooltip", () => {
+    const result = formatWeek(baseInfo(0.18), undefined, undefined);
+    expect(result!.label).toBe("Week: 18%");
+    expect(result!.tooltip).toContain("Weekly Opus: 18% used");
+  });
+
+  it("appends Sonnet line to tooltip when both present", () => {
+    const result = formatWeek(baseInfo(0.18), baseInfo(0.07), undefined);
+    expect(result!.label).toBe("Week: 18%");
+    expect(result!.tooltip).toContain("Weekly Opus: 18% used");
+    expect(result!.tooltip).toContain("Weekly Sonnet: 7% used");
+  });
+
+  it("uses the generic seven_day bucket when opus is missing", () => {
+    const result = formatWeek(undefined, undefined, baseInfo(0.42));
+    expect(result!.label).toBe("Week: 42%");
+    expect(result!.tooltip).toContain("Weekly: 42% used");
+  });
+
+  it("falls back to sonnet-only when it's the only bucket with utilization", () => {
+    const result = formatWeek(undefined, baseInfo(0.33), undefined);
+    expect(result!.label).toBe("Week: 33%");
+    expect(result!.tooltip).toContain("Weekly Sonnet: 33% used");
+  });
+});
+
+describe("buildUsageConfigOption", () => {
+  it("always includes context and hidden options", () => {
+    const opt = buildUsageConfigOption("context", null, {});
+    expect(opt.id).toBe("usage");
+    expect(opt.type).toBe("select");
+    const values = (opt as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values).toEqual(["context", "hidden"]);
+  });
+
+  it("omits five_hour when data is not useful", () => {
+    const opt = buildUsageConfigOption(
+      "context",
+      { used: 10, size: 100 },
+      {
+        five_hour: { status: "allowed" },
+      },
+    );
+    const values = (opt as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values).not.toContain("five_hour");
+  });
+
+  it("includes five_hour when utilization is known", () => {
+    const opt = buildUsageConfigOption("context", null, {
+      five_hour: { status: "allowed", utilization: 0.5 },
+    });
+    const values = (opt as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values).toContain("five_hour");
+  });
+
+  it("omits week when no utilization is present on any weekly bucket", () => {
+    const opt = buildUsageConfigOption("context", null, {
+      seven_day: { status: "allowed", resetsAt: NOW_S + 86400 },
+    });
+    const values = (opt as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values).not.toContain("week");
+  });
+
+  it("includes week when opus utilization is present", () => {
+    const opt = buildUsageConfigOption("week", null, {
+      seven_day_opus: { status: "allowed", utilization: 0.2 },
+    });
+    const values = (opt as { options: { value: string }[] }).options.map((o) => o.value);
+    expect(values).toContain("week");
+  });
+
+  it("renders an empty-named hidden option", () => {
+    const opt = buildUsageConfigOption("hidden", { used: 10, size: 100 }, {});
+    const hidden = (opt as { options: { value: string; name: string }[] }).options.find(
+      (o) => o.value === "hidden",
+    );
+    expect(hidden).toBeDefined();
+    expect(hidden!.name).toBe("");
+  });
+
+  it("preserves currentValue when the preferred view is available", () => {
+    const opt = buildUsageConfigOption("five_hour", null, {
+      five_hour: { status: "allowed", utilization: 0.5 },
+    });
+    expect((opt as { currentValue: string }).currentValue).toBe("five_hour");
+  });
+
+  it("falls back currentValue to context when preferred view is absent", () => {
+    // User previously selected five_hour, but no five_hour data this turn.
+    const opt = buildUsageConfigOption("five_hour", { used: 10, size: 100 }, {});
+    expect((opt as { currentValue: string }).currentValue).toBe("context");
+  });
+
+  it("keeps hidden as currentValue when explicitly selected", () => {
+    const opt = buildUsageConfigOption("hidden", null, {});
+    expect((opt as { currentValue: string }).currentValue).toBe("hidden");
+  });
+});

--- a/src/usage.ts
+++ b/src/usage.ts
@@ -1,0 +1,144 @@
+import type { SessionConfigOption, SessionConfigSelectOption } from "@agentclientprotocol/sdk";
+import type { SDKRateLimitInfo } from "@anthropic-ai/claude-agent-sdk";
+
+export type UsageView = "context" | "five_hour" | "week" | "hidden";
+export type UsageRateLimitKey = "five_hour" | "seven_day_opus" | "seven_day_sonnet" | "seven_day";
+
+type LabelTooltip = { label: string; tooltip: string };
+
+export function buildUsageConfigOption(
+  view: UsageView,
+  context: { used: number; size: number } | null,
+  rateLimits: Partial<Record<UsageRateLimitKey, SDKRateLimitInfo>>,
+): SessionConfigOption {
+  const ctx = formatContextUsage(context);
+  const five = formatFiveHour(rateLimits.five_hour);
+  const week = formatWeek(
+    rateLimits.seven_day_opus,
+    rateLimits.seven_day_sonnet,
+    rateLimits.seven_day,
+  );
+
+  const options: SessionConfigSelectOption[] = [
+    { value: "context", name: ctx.label, description: ctx.tooltip },
+  ];
+  if (five) options.push({ value: "five_hour", name: five.label, description: five.tooltip });
+  if (week) options.push({ value: "week", name: week.label, description: week.tooltip });
+  options.push({
+    value: "hidden",
+    name: "",
+    description:
+      "Collapses this dropdown to just the selector chevron. Pick this if you don't want context or cooldown info on screen.",
+  });
+
+  // If the preferred view isn't currently in the list (e.g. rate-limit data
+  // hasn't arrived yet), fall back to "context" for what's shown on the
+  // closed button. The caller keeps the stored preference so selection
+  // restores when data becomes available again.
+  const available = new Set(options.map((o) => o.value));
+  const currentValue = available.has(view) ? view : "context";
+
+  return {
+    id: "usage",
+    name: "Usage",
+    description: "Context and rate-limit usage",
+    type: "select",
+    currentValue,
+    options,
+  };
+}
+
+export function formatContextUsage(context: { used: number; size: number } | null): LabelTooltip {
+  if (!context || context.size <= 0) {
+    return { label: "Ctx: —", tooltip: "Context usage not yet available." };
+  }
+  const pct = Math.round((context.used / context.size) * 100);
+  return {
+    label: `Ctx: ${pct}%`,
+    tooltip: `Context: ${formatTokens(context.used)} / ${formatTokens(context.size)} tokens (${pct}%)`,
+  };
+}
+
+/** Build the 5-hour label+tooltip, or return null to hide the option entirely
+ *  (no resetsAt and no utilization available — nothing useful to display). */
+export function formatFiveHour(info: SDKRateLimitInfo | undefined): LabelTooltip | null {
+  if (!info) return null;
+  const pct = info.utilization !== undefined ? Math.round(info.utilization * 100) : null;
+  const resetIn = formatResetIn(info.resetsAt);
+  const resetAt = formatResetAt(info.resetsAt);
+  if (pct === null && resetIn === null) return null;
+
+  const labelParts = ["5h"];
+  if (pct !== null) labelParts.push(`${pct}%`);
+  if (resetIn) labelParts.push(resetIn);
+  const label = labelParts.join(" ");
+
+  const tooltipParts: string[] = [];
+  tooltipParts.push(
+    pct !== null ? `5-hour limit: ${pct}% used` : "5-hour limit: usage unknown until threshold",
+  );
+  if (resetAt) tooltipParts.push(`resets at ${resetAt}`);
+  if (info.status === "allowed_warning") tooltipParts.push("status: approaching limit");
+  if (info.status === "rejected") tooltipParts.push("status: limit reached");
+  return { label, tooltip: tooltipParts.join(" · ") };
+}
+
+/** Build the weekly label+tooltip, or return null to hide the option when no
+ *  weekly utilization is present. Weekly data only arrives once a warning
+ *  threshold has been crossed, so the option is omitted during normal use. */
+export function formatWeek(
+  opus: SDKRateLimitInfo | undefined,
+  sonnet: SDKRateLimitInfo | undefined,
+  generic: SDKRateLimitInfo | undefined,
+): LabelTooltip | null {
+  const primary = opus ?? generic ?? sonnet;
+  if (!primary || primary.utilization === undefined) return null;
+
+  const pct = Math.round(primary.utilization * 100);
+  const label = `Week: ${pct}%`;
+
+  const lines: string[] = [];
+  if (opus) lines.push(weeklyLine("Weekly Opus", opus));
+  else if (generic) lines.push(weeklyLine("Weekly", generic));
+  if (sonnet) lines.push(weeklyLine("Weekly Sonnet", sonnet));
+  return { label, tooltip: lines.join("\n") };
+}
+
+function weeklyLine(prefix: string, info: SDKRateLimitInfo): string {
+  const pct = info.utilization !== undefined ? Math.round(info.utilization * 100) : null;
+  const resetAt = formatResetAt(info.resetsAt);
+  const pctStr = pct !== null ? `${pct}% used` : "usage unknown";
+  return `${prefix}: ${pctStr}${resetAt ? `, resets ${resetAt}` : ""}`;
+}
+
+export function formatTokens(tokens: number): string {
+  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(2)}M`;
+  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(0)}k`;
+  return String(tokens);
+}
+
+export function formatResetIn(resetsAt: number | undefined): string | null {
+  if (resetsAt === undefined) return null;
+  const msLeft = resetsAt * 1000 - Date.now();
+  if (msLeft <= 0) return null;
+  const totalMinutes = Math.floor(msLeft / 60_000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}:${minutes.toString().padStart(2, "0")}`;
+}
+
+/** Format an absolute reset timestamp in the user's local timezone, including
+ *  a short tz name so the value is unambiguous in the tooltip. */
+export function formatResetAt(resetsAt: number | undefined): string | null {
+  if (resetsAt === undefined) return null;
+  const date = new Date(resetsAt * 1000);
+  const sameDay = new Date().toDateString() === date.toDateString();
+  const time = date.toLocaleTimeString([], {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZoneName: "short",
+  });
+  if (sameDay) return time;
+  const day = date.toLocaleDateString([], { weekday: "short", month: "short", day: "numeric" });
+  return `${day} ${time}`;
+}


### PR DESCRIPTION
## Summary

Adds a display-only session config option, `Usage`, that surfaces live context-window and rate-limit usage as a dropdown. The option's `currentValue` picks which metric is shown on the closed dropdown button:

- `Ctx: 45%` - context window
- `5h 62% 2:15` — utilization and/or time until reset as `H:MM`
- `Week: 18%` — Opus weekly; Sonnet appended in the tooltip
- `(hidden)` — empty label, collapses to just the chevron

Per-option `description` fields carry the verbose details (absolute token counts, reset times with timezone, approaching-limit status, weekly Opus vs Sonnet) — Zed renders these as tooltips.

## Why as a session config option

`SessionConfigOption` is the only spot in the current ACP spec that lets an agent push a persistent, user-visible indicator into the client UI without requiring a client-side change. `SessionUpdate::UsageUpdate` already covers context tokens, but:

- It's `UNSTABLE` and gated behind `AcpBetaFeatureFlag` on the Zed side.
- It has no surface for rate-limit info — Zed's only limit-style UI is driven off `token_usage.ratio()`.

Using a select dropdown lets the user pick which of three metrics they want on-screen, with the others a click away in the list. It also degrades gracefully: the 5h and Week options are hidden entirely when the SDK hasn't emitted useful data for them, so the dropdown stays tidy during normal use. This is purely additive — the data comes from the existing SDK connection (`rate_limit_event` messages plus `lastAssistantTotalUsage` / `contextWindowSize` already tracked for `usage_update`).

## Screenshots

Note: Screenshots taken combined with effort selector code present in `rohan-patra/claude-agent-acp/main`.

<img width="670" height="30" alt="Screenshot 2026-04-19 at 1 33 29 PM" src="https://github.com/user-attachments/assets/09be38bd-29a9-455d-b303-550fd354c264" />\
_Context Limit (default)_
<br/>

<img width="755" height="137" alt="Screenshot 2026-04-19 at 1 33 55 PM" src="https://github.com/user-attachments/assets/39b656dd-cdcb-4e29-923b-683297d5f261" />\
_5hr reset timer. % used will show over 85%._
<br/>

<img width="678" height="28" alt="Screenshot 2026-04-19 at 1 34 03 PM" src="https://github.com/user-attachments/assets/44012433-45c5-45ce-afe2-9dee19fede4d" />\
_Hidden_
<br/>

## Limitations of this implementation

- **Weekly usage data is rarely visible.** The SDK only emits `seven_day_opus` / `seven_day_sonnet` utilization once a warning threshold has been crossed. In normal use, only `resetsAt` arrives, and we hide the Week option rather than render a mostly-empty label. Filed upstream: https://github.com/anthropics/claude-code/issues/50518.
- **No dropdown-placement control.** ACP has no field for left-align / compact rendering; that's a client-side concern. In Zed today the option sits alongside Mode / Model.
- **Updates fire on every SDK event, not on a timer.** Both `rate_limit_event` and `result` paths synchronously emit a `config_option_update`. In practice these arrive infrequently enough (once per turn / once per rate-limit transition) that no debounce is warranted — an earlier debounced version was reviewed and backed out as overengineered.
- **Countdown labels go stale while idle.** The `5h 62% 2:15` label is built on the SDK event; we don't re-push the countdown while the session sits between prompts. The minute-precision label stays close enough for the human eye for the ~minutes-to-hours window it typically covers, but a perfectly ticking countdown would need either a per-session timer or a Zed-side re-render hook.
- **Weekly label only reads Opus.** When both Opus and Sonnet utilization are present, only Opus drives the label percentage; Sonnet appears in the tooltip. This matches the user's typical concern (weekly Opus budget being scarcer) but is a preference baked into `formatWeek`.

## Future

Should the SDK start supporting sharing the required data in a hook rather than this message event, we would want to migrate to that as source of truth. Supporting a countdown on the reset timer would also be trivial to support, just wasn't warranted for this implementation.

## Disclosure

This change was largely generated with Claude Code (Opus 4.7 1M) and reviewed + tested end-to-end in Zed. The formatters in `src/usage.ts` are pure and covered by 42 unit tests in `src/tests/usage.test.ts`; 4 additional tests in `src/tests/acp-agent.test.ts` verify `rate_limit_event` → `config_option_update` push behavior.

## Test plan

- [x] `npm run build`
- [x] `npm run test:run` (227 pass; 3 pre-existing `authorization.test.ts` failures on `main` are unrelated)
- [x] Verified dropdown labels and tooltips in Zed across: initial state (Ctx only), after rate-limit warning threshold (5h appears), after weekly warning (Week appears), and with hidden selected