### PR TITLE
fix: honor availableModels from Claude settings

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2023,19 +2023,31 @@ async function getAvailableModels(
 ): Promise<SessionModelState> {
   const settings = settingsManager.getSettings();
 
-  let currentModel = models[0];
+  const configuredAvailableModels = settings.availableModels?.filter(
+    (model): model is string => typeof model === "string" && model.trim().length > 0,
+  );
+  const filteredModels = configuredAvailableModels?.length
+    ? models.filter((model) =>
+        configuredAvailableModels.some(
+          (configuredModel) => resolveModelPreference([model], configuredModel)?.value === model.value,
+        ),
+      )
+    : models;
+  const visibleModels = filteredModels.length > 0 ? filteredModels : models;
+
+  let currentModel = visibleModels[0];
 
   // Model priority (highest to lowest):
   // 1. ANTHROPIC_MODEL environment variable
   // 2. settings.model (user configuration)
-  // 3. models[0] (default first model)
+  // 3. first visible model
   if (process.env.ANTHROPIC_MODEL) {
-    const match = resolveModelPreference(models, process.env.ANTHROPIC_MODEL);
+    const match = resolveModelPreference(visibleModels, process.env.ANTHROPIC_MODEL);
     if (match) {
       currentModel = match;
     }
   } else if (settings.model) {
-    const match = resolveModelPreference(models, settings.model);
+    const match = resolveModelPreference(visibleModels, settings.model);
     if (match) {
       currentModel = match;
     }
@@ -2044,7 +2056,7 @@ async function getAvailableModels(
   await query.setModel(currentModel.value);
 
   return {
-    availableModels: models.map((model) => ({
+    availableModels: visibleModels.map((model) => ({
       modelId: model.value,
       name: model.displayName,
       description: model.description,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -22,6 +22,7 @@ export interface ClaudeCodeSettings {
   permissions?: PermissionSettings;
   env?: Record<string, string>;
   model?: string;
+  availableModels?: string[];
   effortLevel?: string;
 }
 
@@ -187,6 +188,10 @@ export class SettingsManager {
 
       if (settings.model) {
         merged.model = settings.model;
+      }
+
+      if (settings.availableModels !== undefined) {
+        merged.availableModels = settings.availableModels;
       }
 
       if (settings.effortLevel !== undefined) {

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -217,4 +217,115 @@ describe("ClaudeAcpAgent settings", () => {
     expect(setModelSpy).toHaveBeenCalledWith("claude-opus-4-6-1m");
     expect(response.models.currentModelId).toBe("claude-opus-4-6-1m");
   });
+
+  it("filters visible models using availableModels", async () => {
+    await fs.promises.writeFile(
+      path.join(tempDir, "settings.json"),
+      JSON.stringify({
+        availableModels: ["claude-opus-4-6-1m"],
+      }),
+    );
+
+    const projectDir = path.join(tempDir, "project");
+    await fs.promises.mkdir(projectDir, { recursive: true });
+
+    const setModelSpy = vi.fn();
+    querySpy.mockImplementation(() => {
+      return {
+        initializationResult: async () => ({
+          models: [
+            {
+              value: "claude-opus-4-6",
+              displayName: "Claude Opus 4.6",
+              description: "Base",
+            },
+            {
+              value: "claude-opus-4-6-1m",
+              displayName: "Claude Opus 4.6 (1M)",
+              description: "Long context",
+            },
+          ],
+        }),
+        setModel: setModelSpy,
+        supportedCommands: async () => [],
+      } as any;
+    });
+
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
+
+    const response = await (agent as any).createSession({
+      cwd: projectDir,
+      mcpServers: [],
+      _meta: { disableBuiltInTools: true },
+    });
+
+    expect(setModelSpy).toHaveBeenCalledWith("claude-opus-4-6-1m");
+    expect(response.models.availableModels).toEqual([
+      {
+        modelId: "claude-opus-4-6-1m",
+        name: "Claude Opus 4.6 (1M)",
+        description: "Long context",
+      },
+    ]);
+    expect(response.models.currentModelId).toBe("claude-opus-4-6-1m");
+  });
+
+  it("falls back to the SDK model list when availableModels has no matches", async () => {
+    await fs.promises.writeFile(
+      path.join(tempDir, "settings.json"),
+      JSON.stringify({
+        availableModels: ["gpt-5.4"],
+      }),
+    );
+
+    const projectDir = path.join(tempDir, "project");
+    await fs.promises.mkdir(projectDir, { recursive: true });
+
+    const setModelSpy = vi.fn();
+    querySpy.mockImplementation(() => {
+      return {
+        initializationResult: async () => ({
+          models: [
+            {
+              value: "claude-sonnet-4-5",
+              displayName: "Claude Sonnet 4.5",
+              description: "Default",
+            },
+            {
+              value: "claude-opus-4-6",
+              displayName: "Claude Opus 4.6",
+              description: "Most capable",
+            },
+          ],
+        }),
+        setModel: setModelSpy,
+        supportedCommands: async () => [],
+      } as any;
+    });
+
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
+
+    const response = await (agent as any).createSession({
+      cwd: projectDir,
+      mcpServers: [],
+      _meta: { disableBuiltInTools: true },
+    });
+
+    expect(setModelSpy).toHaveBeenCalledWith("claude-sonnet-4-5");
+    expect(response.models.availableModels).toEqual([
+      {
+        modelId: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        description: "Default",
+      },
+      {
+        modelId: "claude-opus-4-6",
+        name: "Claude Opus 4.6",
+        description: "Most capable",
+      },
+    ]);
+    expect(response.models.currentModelId).toBe("claude-sonnet-4-5");
+  });
 });

--- a/src/tests/settings.test.ts
+++ b/src/tests/settings.test.ts
@@ -89,5 +89,37 @@ describe("SettingsManager", () => {
       settings = settingsManager.getSettings();
       expect(settings.permissions?.defaultMode).toBe("plan");
     });
+
+    it("should merge availableModels with later sources taking precedence", async () => {
+      const claudeDir = path.join(tempDir, ".claude");
+      await fs.promises.mkdir(claudeDir, { recursive: true });
+
+      await fs.promises.writeFile(
+        path.join(claudeDir, "settings.json"),
+        JSON.stringify({
+          availableModels: ["claude-3-5-sonnet", "claude-3-5-haiku"],
+        }),
+      );
+
+      settingsManager = new SettingsManager(tempDir);
+      await settingsManager.initialize();
+
+      let settings = settingsManager.getSettings();
+      expect(settings.availableModels).toEqual(["claude-3-5-sonnet", "claude-3-5-haiku"]);
+
+      await fs.promises.writeFile(
+        path.join(claudeDir, "settings.local.json"),
+        JSON.stringify({
+          availableModels: ["claude-3-7-sonnet"],
+        }),
+      );
+
+      settingsManager.dispose();
+      settingsManager = new SettingsManager(tempDir);
+      await settingsManager.initialize();
+
+      settings = settingsManager.getSettings();
+      expect(settings.availableModels).toEqual(["claude-3-7-sonnet"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- add `availableModels` to the Claude settings schema and merge it with existing settings precedence
- filter the ACP model list using configured `availableModels` while preserving existing default-model resolution
- add coverage for visible-model filtering, fallback behavior, and settings merging

## Test plan
- [x] Not run locally per requester preference
- [ ] Maintainers can run the existing test suite in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)