### PR TITLE
fix: Forward SDKAssistantMessage.error as structured data on internal errors

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -54,6 +54,7 @@ import {
   Query,
   query,
   Settings,
+  SDKAssistantMessageError,
   SDKPartialAssistantMessage,
   SDKUserMessage,
   SlashCommand,
@@ -590,6 +591,13 @@ export class ClaudeAcpAgent implements Agent {
     let lastAssistantTotalUsage: number | null = null;
     let lastAssistantUsage: UsageSnapshot | null = null;
     let lastAssistantModel: string | null = null;
+    // When the Claude SDK classifies a turn as failed (e.g. rate limit, auth
+    // problem, billing), it sets a categorical `error` field on the
+    // `SDKAssistantMessage` that precedes the final `result` message. We
+    // capture it here so the subsequent `RequestError.internalError` can
+    // forward it to clients as structured `data`, sparing them from
+    // pattern-matching on the human-readable message text.
+    let lastAssistantError: SDKAssistantMessageError | undefined;
 
     const userMessage = promptToClaude(params);
 
@@ -775,7 +783,10 @@ export class ClaudeAcpAgent implements Agent {
                   break;
                 }
                 if (message.is_error) {
-                  throw RequestError.internalError(undefined, message.result);
+                  throw RequestError.internalError(
+                    errorKindData(lastAssistantError),
+                    message.result,
+                  );
                 }
                 // For local-only commands (no model invocation), the result
                 // text is the command output — forward it to the client.
@@ -800,7 +811,7 @@ export class ClaudeAcpAgent implements Agent {
                 }
                 if (message.is_error) {
                   throw RequestError.internalError(
-                    undefined,
+                    errorKindData(lastAssistantError),
                     message.errors.join(", ") || message.subtype,
                   );
                 }
@@ -812,7 +823,7 @@ export class ClaudeAcpAgent implements Agent {
               case "error_max_structured_output_retries":
                 if (message.is_error) {
                   throw RequestError.internalError(
-                    undefined,
+                    errorKindData(lastAssistantError),
                     message.errors.join(", ") || message.subtype,
                   );
                 }
@@ -927,6 +938,9 @@ export class ClaudeAcpAgent implements Agent {
               lastAssistantTotalUsage = totalTokens(lastAssistantUsage);
               if (message.message.model && message.message.model !== "<synthetic>") {
                 lastAssistantModel = message.message.model;
+              }
+              if (message.error) {
+                lastAssistantError = message.error;
               }
             }
 
@@ -1830,6 +1844,22 @@ function totalTokens(usage: UsageSnapshot): number {
     usage.cache_read_input_tokens +
     usage.cache_creation_input_tokens
   );
+}
+
+/**
+ * Build the `data` payload attached to a `RequestError.internalError` when we
+ * have a categorical error from the Claude SDK. Returns `undefined` when no
+ * categorical error is available, matching the previous behavior of passing
+ * `undefined` to `RequestError.internalError`.
+ *
+ * The `errorKind` field is a convention for ACP clients to dispatch on
+ * without having to pattern-match the human-readable message text. Clients
+ * that don't understand it fall back to the existing message-based rendering.
+ */
+function errorKindData(
+  errorKind: SDKAssistantMessageError | undefined,
+): { errorKind: SDKAssistantMessageError } | undefined {
+  return errorKind ? { errorKind } : undefined;
 }
 
 /** Project a nullable API usage object into our non-null snapshot shape.

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1529,6 +1529,87 @@ describe("stop reason propagation", () => {
       }),
     ).rejects.toThrow("Internal error");
   });
+
+  it("forwards SDKAssistantMessage.error as structured data on internal errors", async () => {
+    const agent = createMockAgent();
+    const assistantMessage: SDKAssistantMessage = {
+      type: "assistant",
+      parent_tool_use_id: null,
+      error: "rate_limit",
+      uuid: randomUUID(),
+      session_id: "test-session",
+      message: {
+        id: "msg-1",
+        type: "message",
+        role: "assistant",
+        container: null,
+        model: "claude-sonnet-4-20250514",
+        content: [],
+        stop_reason: "stop_sequence",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          server_tool_use: { web_search_requests: 0, web_fetch_requests: 0 },
+          service_tier: null,
+          cache_creation: {
+            ephemeral_1h_input_tokens: 0,
+            ephemeral_5m_input_tokens: 0,
+          },
+        } as any,
+      } as any,
+    };
+
+    injectSession(agent, [
+      assistantMessage,
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "You've hit your limit · resets 8pm",
+      }),
+    ]);
+
+    const err = await agent
+      .prompt({
+        sessionId: "test-session",
+        prompt: [{ type: "text", text: "test" }],
+      })
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err).not.toBeNull();
+    expect((err as { data: unknown }).data).toEqual({ errorKind: "rate_limit" });
+  });
+
+  it("omits errorKind data when no SDKAssistantMessage.error was observed", async () => {
+    const agent = createMockAgent();
+    injectSession(agent, [
+      createResultMessage({
+        subtype: "success",
+        stop_reason: "end_turn",
+        is_error: true,
+        result: "Something went wrong",
+      }),
+    ]);
+
+    const err = await agent
+      .prompt({
+        sessionId: "test-session",
+        prompt: [{ type: "text", text: "test" }],
+      })
+      .then(
+        () => null,
+        (e) => e,
+      );
+
+    expect(err).not.toBeNull();
+    expect((err as { data: unknown }).data).toBeUndefined();
+  });
 });
 
 describe("session/close", () => {


### PR DESCRIPTION
## Motivation

When a Zed user on the Claude Pro tier hits their usage limit, Zed receives an error like this from claude-agent-acp:

```json
{
  "code": -32603,
  "message": "Internal error: You've hit your limit \u00b7 resets 8pm (America/Los_Angeles)",
  "data": undefined
}
```

The only way for a client to recognize this as a rate-limit condition (vs. any of the other things that can hit the `is_error: true` path — billing issues, server errors, max tokens, etc.) is to pattern-match on the human-readable message text. That's fragile and breaks every time the message gets reworded upstream.

## What Claude Code already provides

The Claude Agent SDK actually emits a categorical kind on the `SDKAssistantMessage` that precedes the failing `result`:

```ts
export declare type SDKAssistantMessageError =
  | 'authentication_failed'
  | 'billing_error'
  | 'rate_limit'
  | 'invalid_request'
  | 'server_error'
  | 'unknown'
  | 'max_output_tokens';
```

\(Confirmed by inspection of the shipped `cli.js`: the CLI calls a helper that wraps errors into assistant messages with `error: "rate_limit"` \(or `billing_error`, etc.\) based on the nature of the failure.\)

The adapter today reads `message.message.usage`, `message.message.model`, and `message.message.content` off the `SDKAssistantMessage`, but ignores the top-level `error` field. By the time we throw `RequestError.internalError\(undefined, message.result\)` on the failing result, the categorical info has been discarded.

## This PR

Capture the last seen `SDKAssistantMessage.error` and forward it to `RequestError.internalError`'s `data` as `{ errorKind }`:

```json
{
  "code": -32603,
  "message": "Internal error: You've hit your limit \u00b7 resets 8pm (America/Los_Angeles)",
  "data": { "errorKind": "rate_limit" }
}
```

ACP clients can then dispatch on the structured kind instead of pattern-matching on the message text. Clients that don't understand the field fall back to the existing message-based rendering unchanged \(`data` is now populated in some cases where it used to be `undefined`, but that's purely additive — no existing client reads this field today so there's no compatibility risk\).

When the SDK doesn't provide a categorical error, we continue to pass `undefined` so `data` stays absent.

## Changes

- `src/acp-agent.ts`: Track a `lastAssistantError: SDKAssistantMessageError | undefined` through the `prompt()` iteration, populated from the assistant branch. Thread it through to all three `throw RequestError.internalError` sites in the result branch via a small `errorKindData` helper.
- `src/tests/acp-agent.test.ts`: Two new tests — one verifying that an upstream `error: "rate_limit"` on an `SDKAssistantMessage` shows up as `{ errorKind: "rate_limit" }` on the thrown error's `data`, one verifying that absence stays `undefined`.

## Open questions

1. **Field name.** I went with `errorKind` since it's short, agent-agnostic, and not conflated with JSON-RPC's own `code`. Open to bikeshedding.
2. **Whether to push this toward being an ACP-wide convention.** Other adapters \(codex, gemini\) face the same problem — everything non-auth squashed into `InternalError`. If this lands and works well here, it might be worth writing up a little guidance in the ACP docs for "how adapters should encode categorical error reasons" so we get the same shape from every agent.
3. **Companion Zed PR.** The Zed-side change to read `data.errorKind` and map to the existing `ThreadError::RateLimitExceeded` / `AuthenticationRequired` / `PaymentRequired` / `MaxOutputTokens` variants is straightforward \(~20 lines\) but I've held off on it until this ships and a release is cut.

## Testing

- `npm run test:run`: 199 passing \(was 197; 2 new\).
- `npm run build`: clean.
- `npm run check`: lint + format clean.

This is part of a broader quality-week effort in Zed to improve the external-agent debugging experience \(<https://github.com/zed-industries/zed/issues/54531>\).