### PR TITLE
fix: Fall through to next CLI candidate on ENOENT spawn

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -62,6 +62,7 @@ import {
 } from "@anthropic-ai/claude-agent-sdk";
 import { ContentBlockParam } from "@anthropic-ai/sdk/resources";
 import { BetaContentBlock, BetaRawContentBlockDelta } from "@anthropic-ai/sdk/resources/beta.mjs";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -264,34 +265,64 @@ export type ToolUseCache = {
   };
 };
 
-export async function claudeCliPath(): Promise<string> {
-  if (process.env.CLAUDE_CODE_EXECUTABLE) {
-    return process.env.CLAUDE_CODE_EXECUTABLE;
-  }
+export async function spawnClaudeCli(
+  args: ReadonlyArray<string>,
+  options: SpawnOptions,
+): Promise<ChildProcess> {
   // The SDK's CLI is a native binary shipped as a platform-specific optional
-  // dependency of @anthropic-ai/claude-agent-sdk. Resolve via a require bound
-  // to the SDK so nested installs are found even when npm doesn't hoist.
+  // dependency of @anthropic-ai/claude-agent-sdk. On linux, both glibc and musl
+  // variants may resolve via require (e.g. bunx pre-installs both) even when
+  // only one is actually present on disk, so we try each candidate and fall
+  // through if spawn fails with ENOENT.
+  const candidates = await claudeCliCandidates();
+  let lastError: unknown;
+  for (const candidate of candidates) {
+    const child = spawn(candidate, args as string[], options);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        child.once("spawn", () => resolve());
+        child.once("error", reject);
+      });
+      return child;
+    } catch (err) {
+      lastError = err;
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") throw err;
+    }
+  }
+  throw (
+    lastError ??
+    new Error(
+      `Claude native binary not found for ${process.platform}-${process.arch}. ` +
+        `Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set CLAUDE_CODE_EXECUTABLE.`,
+    )
+  );
+}
+
+async function claudeCliCandidates(): Promise<string[]> {
+  if (process.env.CLAUDE_CODE_EXECUTABLE) {
+    return [process.env.CLAUDE_CODE_EXECUTABLE];
+  }
+  // Resolve via a require bound to the SDK so nested installs are found even
+  // when npm doesn't hoist.
   const { createRequire } = await import("node:module");
   const req = createRequire(import.meta.resolve("@anthropic-ai/claude-agent-sdk"));
   const ext = process.platform === "win32" ? ".exe" : "";
-  const candidates =
+  const names =
     process.platform === "linux"
       ? [
-          `@anthropic-ai/claude-agent-sdk-linux-${process.arch}-musl/claude${ext}`,
           `@anthropic-ai/claude-agent-sdk-linux-${process.arch}/claude${ext}`,
+          `@anthropic-ai/claude-agent-sdk-linux-${process.arch}-musl/claude${ext}`,
         ]
       : [`@anthropic-ai/claude-agent-sdk-${process.platform}-${process.arch}/claude${ext}`];
-  for (const candidate of candidates) {
+  const paths: string[] = [];
+  for (const name of names) {
     try {
-      return req.resolve(candidate);
+      paths.push(req.resolve(name));
     } catch {
-      // try next candidate
+      // package not installed
     }
   }
-  throw new Error(
-    `Claude native binary not found for ${process.platform}-${process.arch}. ` +
-      `Reinstall @anthropic-ai/claude-agent-sdk without --omit=optional, or set CLAUDE_CODE_EXECUTABLE.`,
-  );
+  return paths;
 }
 
 function shouldHideClaudeAuth(): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,11 @@
 
 // Load managed settings and apply environment variables
 import { loadManagedSettings, applyEnvironmentSettings } from "./utils.js";
-import { claudeCliPath, runAcp } from "./acp-agent.js";
+import { runAcp, spawnClaudeCli } from "./acp-agent.js";
 
 if (process.argv.includes("--cli")) {
-  const { spawn } = await import("node:child_process");
   const args = process.argv.slice(2).filter((arg) => arg !== "--cli");
-  const child = spawn(await claudeCliPath(), args, { stdio: "inherit" });
+  const child = await spawnClaudeCli(args, { stdio: "inherit" });
 
   const signals =
     process.platform === "win32"

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -30,8 +30,8 @@ import {
   isLocalCommandMetadata,
   stripLocalCommandMetadata,
   ClaudeAcpAgent,
-  claudeCliPath,
   describeAlwaysAllow,
+  spawnClaudeCli,
 } from "../acp-agent.js";
 import { Pushable } from "../utils.js";
 import { query, SDKAssistantMessage } from "@anthropic-ai/claude-agent-sdk";
@@ -1276,9 +1276,12 @@ describe("prompt conversion", () => {
 });
 
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("SDK behavior", () => {
-  it("finds vendored cli path", async () => {
-    const path = await claudeCliPath();
-    expect(path).toMatch(/@anthropic-ai\/claude-agent-sdk-[^/]+\/claude(\.exe)?$/);
+  it("spawns vendored cli", async () => {
+    const child = await spawnClaudeCli(["--version"], { stdio: "ignore" });
+    const code = await new Promise<number | null>((resolve) => {
+      child.once("exit", (code) => resolve(code));
+    });
+    expect(code).toBe(0);
   });
 
   it("query has a 'default' model", async () => {


### PR DESCRIPTION
When bunx installs the agent, it materializes both the glibc and musl optional dependencies as resolvable packages even though only one ships the actual binary on disk. The previous resolve-time fallback returned the musl path successfully, then `spawn` failed with ENOENT at runtime.

Replace `claudeCliPath` with `spawnClaudeCli`, which spawns each resolved candidate and falls through on ENOENT, and tries glibc before musl.

Assisted by: Claude Opus 4.7