### PR TITLE
fix: tolerate invalid values in settings.json

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1718,9 +1718,20 @@ export class ClaudeAcpAgent implements Agent {
       }
     }
 
-    const permissionMode = resolvePermissionMode(
-      settingsManager.getSettings().permissions?.defaultMode,
-    );
+    const configuredDefaultMode = settingsManager.getSettings().permissions?.defaultMode;
+    let permissionMode: PermissionMode;
+    try {
+      permissionMode = resolvePermissionMode(configuredDefaultMode);
+    } catch (error) {
+      // Bad value in settings should not crash session creation — fall back to
+      // the default mode and log so the user can see why their setting was
+      // ignored. Mirrors how the Claude Code SDK tolerates broken settings.
+      this.logger.error(
+        `Ignoring permissions.defaultMode from settings:`,
+        error instanceof Error ? error.message : error,
+      );
+      permissionMode = "default";
+    }
 
     // Extract options from _meta if provided
     const sessionMeta = params._meta as NewSessionMeta | undefined;
@@ -1858,7 +1869,12 @@ export class ClaudeAcpAgent implements Agent {
       );
     }
 
-    const models = await getAvailableModels(q, initializationResult.models, settingsManager);
+    const models = await getAvailableModels(
+      q,
+      initializationResult.models,
+      settingsManager,
+      this.logger,
+    );
 
     const availableModes = [
       {
@@ -2193,6 +2209,7 @@ async function getAvailableModels(
   query: Query,
   models: ModelInfo[],
   settingsManager: SettingsManager,
+  logger: Logger,
 ): Promise<SessionModelState> {
   const settings = settingsManager.getSettings();
 
@@ -2207,10 +2224,19 @@ async function getAvailableModels(
     if (match) {
       currentModel = match;
     }
-  } else if (settings.model) {
-    const match = resolveModelPreference(models, settings.model);
-    if (match) {
-      currentModel = match;
+  } else if (settings.model !== undefined) {
+    if (typeof settings.model === "string") {
+      const match = resolveModelPreference(models, settings.model);
+      if (match) {
+        currentModel = match;
+      }
+    } else {
+      // Bad value in settings should not crash session creation — log and
+      // fall back to the SDK's default model. Mirrors how broken settings
+      // are tolerated elsewhere.
+      logger.error(
+        `Ignoring model from settings: expected a string, got ${typeof settings.model}`,
+      );
     }
   }
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2212,9 +2212,7 @@ function resolveSettingsModel(
   }
   if (typeof settingsModel !== "string") {
     const typeLabel = settingsModel === null ? "null" : typeof settingsModel;
-    logger.error(
-      `Ignoring model from settings: expected a string, got ${typeLabel}.`,
-    );
+    logger.error(`Ignoring model from settings: expected a string, got ${typeLabel}.`);
     return null;
   }
   return resolveModelPreference(models, settingsModel);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -385,29 +385,36 @@ const PERMISSION_MODE_ALIASES: Record<string, PermissionMode> = {
   bypass: "bypassPermissions",
 };
 
-export function resolvePermissionMode(defaultMode?: unknown): PermissionMode {
+export function resolvePermissionMode(
+  defaultMode?: unknown,
+  logger: Logger = console,
+): PermissionMode {
   if (defaultMode === undefined) {
     return "default";
   }
 
   if (typeof defaultMode !== "string") {
-    throw new Error("Invalid permissions.defaultMode: expected a string.");
+    logger.error("Ignoring permissions.defaultMode from settings: expected a string.");
+    return "default";
   }
 
   const normalized = defaultMode.trim().toLowerCase();
   if (normalized === "") {
-    throw new Error("Invalid permissions.defaultMode: expected a non-empty string.");
+    logger.error("Ignoring permissions.defaultMode from settings: expected a non-empty string.");
+    return "default";
   }
 
   const mapped = PERMISSION_MODE_ALIASES[normalized];
   if (!mapped) {
-    throw new Error(`Invalid permissions.defaultMode: ${defaultMode}.`);
+    logger.error(`Ignoring permissions.defaultMode from settings: unknown value '${defaultMode}'.`);
+    return "default";
   }
 
   if (mapped === "bypassPermissions" && !ALLOW_BYPASS) {
-    throw new Error(
-      "Invalid permissions.defaultMode: bypassPermissions is not available when running as root.",
+    logger.error(
+      "Ignoring permissions.defaultMode from settings: bypassPermissions is not available when running as root.",
     );
+    return "default";
   }
 
   return mapped;
@@ -1718,20 +1725,10 @@ export class ClaudeAcpAgent implements Agent {
       }
     }
 
-    const configuredDefaultMode = settingsManager.getSettings().permissions?.defaultMode;
-    let permissionMode: PermissionMode;
-    try {
-      permissionMode = resolvePermissionMode(configuredDefaultMode);
-    } catch (error) {
-      // Bad value in settings should not crash session creation — fall back to
-      // the default mode and log so the user can see why their setting was
-      // ignored. Mirrors how the Claude Code SDK tolerates broken settings.
-      this.logger.error(
-        `Ignoring permissions.defaultMode from settings:`,
-        error instanceof Error ? error.message : error,
-      );
-      permissionMode = "default";
-    }
+    const permissionMode = resolvePermissionMode(
+      settingsManager.getSettings().permissions?.defaultMode,
+      this.logger,
+    );
 
     // Extract options from _meta if provided
     const sessionMeta = params._meta as NewSessionMeta | undefined;
@@ -2205,6 +2202,24 @@ function resolveModelPreference(models: ModelInfo[], preference: string): ModelI
   return bestMatch;
 }
 
+function resolveSettingsModel(
+  models: ModelInfo[],
+  settingsModel: unknown,
+  logger: Logger,
+): ModelInfo | null {
+  if (settingsModel === undefined) {
+    return null;
+  }
+  if (typeof settingsModel !== "string") {
+    const typeLabel = settingsModel === null ? "null" : typeof settingsModel;
+    logger.error(
+      `Ignoring model from settings: expected a string, got ${typeLabel}.`,
+    );
+    return null;
+  }
+  return resolveModelPreference(models, settingsModel);
+}
+
 async function getAvailableModels(
   query: Query,
   models: ModelInfo[],
@@ -2224,19 +2239,10 @@ async function getAvailableModels(
     if (match) {
       currentModel = match;
     }
-  } else if (settings.model !== undefined) {
-    if (typeof settings.model === "string") {
-      const match = resolveModelPreference(models, settings.model);
-      if (match) {
-        currentModel = match;
-      }
-    } else {
-      // Bad value in settings should not crash session creation — log and
-      // fall back to the SDK's default model. Mirrors how broken settings
-      // are tolerated elsewhere.
-      logger.error(
-        `Ignoring model from settings: expected a string, got ${typeof settings.model}`,
-      );
+  } else {
+    const match = resolveSettingsModel(models, settings.model, logger);
+    if (match) {
+      currentModel = match;
     }
   }
 

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -185,22 +185,7 @@ describe("ClaudeAcpAgent settings", () => {
     const projectDir = path.join(tempDir, "project");
     await fs.promises.mkdir(projectDir, { recursive: true });
 
-    const setModelSpy = vi.fn();
-    querySpy.mockImplementation(({ options: _options }: any) => {
-      return {
-        initializationResult: async () => ({
-          models: [
-            {
-              value: "claude-sonnet-4-5",
-              displayName: "Claude Sonnet 4.5",
-              description: "Default",
-            },
-          ],
-        }),
-        setModel: setModelSpy,
-        supportedCommands: async () => [],
-      } as any;
-    });
+    const { setModelSpy } = mockQuery();
 
     const { ClaudeAcpAgent } = await import("../acp-agent.js");
     const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -145,12 +145,12 @@ describe("ClaudeAcpAgent settings", () => {
     expect(response.modes.currentModeId).toBe("default");
   });
 
-  it("throws when permissions.defaultMode is not a string", async () => {
+  it("falls back to 'default' when permissions.defaultMode is invalid", async () => {
     await fs.promises.writeFile(
       path.join(tempDir, "settings.json"),
       JSON.stringify({
         permissions: {
-          defaultMode: 123,
+          defaultMode: "not-a-real-mode",
         },
       }),
     );
@@ -158,18 +158,62 @@ describe("ClaudeAcpAgent settings", () => {
     const projectDir = path.join(tempDir, "project");
     await fs.promises.mkdir(projectDir, { recursive: true });
 
-    mockQuery();
+    const { getCapturedOptions } = mockQuery();
 
     const { ClaudeAcpAgent } = await import("../acp-agent.js");
     const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
 
-    await expect(
-      (agent as any).createSession({
-        cwd: projectDir,
-        mcpServers: [],
-        _meta: { disableBuiltInTools: true },
+    const response = await (agent as any).createSession({
+      cwd: projectDir,
+      mcpServers: [],
+      _meta: { disableBuiltInTools: true },
+    });
+
+    // Bad mode is ignored at the usage site; session creation must not throw.
+    expect(getCapturedOptions().permissionMode).toBe("default");
+    expect(response.modes.currentModeId).toBe("default");
+  });
+
+  it("ignores model from settings when it is not a string", async () => {
+    await fs.promises.writeFile(
+      path.join(tempDir, "settings.json"),
+      JSON.stringify({
+        model: 123,
       }),
-    ).rejects.toThrow("Invalid permissions.defaultMode");
+    );
+
+    const projectDir = path.join(tempDir, "project");
+    await fs.promises.mkdir(projectDir, { recursive: true });
+
+    const setModelSpy = vi.fn();
+    querySpy.mockImplementation(({ options: _options }: any) => {
+      return {
+        initializationResult: async () => ({
+          models: [
+            {
+              value: "claude-sonnet-4-5",
+              displayName: "Claude Sonnet 4.5",
+              description: "Default",
+            },
+          ],
+        }),
+        setModel: setModelSpy,
+        supportedCommands: async () => [],
+      } as any;
+    });
+
+    const { ClaudeAcpAgent } = await import("../acp-agent.js");
+    const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
+
+    const response = await (agent as any).createSession({
+      cwd: projectDir,
+      mcpServers: [],
+      _meta: { disableBuiltInTools: true },
+    });
+
+    // Bad model is ignored at the usage site; falls back to the first SDK model.
+    expect(setModelSpy).toHaveBeenCalledWith("claude-sonnet-4-5");
+    expect(response.models.currentModelId).toBe("claude-sonnet-4-5");
   });
 
   it("resolves model aliases like opus[1m] to the correct model", async () => {

--- a/src/tests/resolve-permission-mode.test.ts
+++ b/src/tests/resolve-permission-mode.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect } from "vitest";
-import { resolvePermissionMode } from "../acp-agent.js";
+import { describe, it, expect, vi } from "vitest";
+import { resolvePermissionMode, type Logger } from "../acp-agent.js";
+
+function mockLogger() {
+  const error = vi.fn<(...args: any[]) => void>();
+  const log = vi.fn<(...args: any[]) => void>();
+  const logger: Logger = { log, error };
+  return { logger, error, log };
+}
 
 describe("resolvePermissionMode", () => {
   it("returns 'default' when no mode is provided", () => {
@@ -26,18 +33,25 @@ describe("resolvePermissionMode", () => {
     expect(resolvePermissionMode("  dontAsk  ")).toBe("dontAsk");
   });
 
-  it("throws on non-string values", () => {
-    expect(() => resolvePermissionMode(123)).toThrow("expected a string");
-    expect(() => resolvePermissionMode(true)).toThrow("expected a string");
-    expect(() => resolvePermissionMode({})).toThrow("expected a string");
+  it("falls back to 'default' and logs on non-string values", () => {
+    for (const value of [123, true, {}]) {
+      const { logger, error } = mockLogger();
+      expect(resolvePermissionMode(value, logger)).toBe("default");
+      expect(error).toHaveBeenCalledWith(expect.stringContaining("expected a string"));
+    }
   });
 
-  it("throws on empty string", () => {
-    expect(() => resolvePermissionMode("")).toThrow("expected a non-empty string");
-    expect(() => resolvePermissionMode("  ")).toThrow("expected a non-empty string");
+  it("falls back to 'default' and logs on empty string", () => {
+    for (const value of ["", "  "]) {
+      const { logger, error } = mockLogger();
+      expect(resolvePermissionMode(value, logger)).toBe("default");
+      expect(error).toHaveBeenCalledWith(expect.stringContaining("expected a non-empty string"));
+    }
   });
 
-  it("throws on unknown mode", () => {
-    expect(() => resolvePermissionMode("yolo")).toThrow("Invalid permissions.defaultMode: yolo");
+  it("falls back to 'default' and logs on unknown mode", () => {
+    const { logger, error } = mockLogger();
+    expect(resolvePermissionMode("yolo", logger)).toBe("default");
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("yolo"));
   });
 });


### PR DESCRIPTION
A broken value in settings.json (e.g. an unknown permissions.defaultMode or a non-string model) used to throw and prevent session creation. Match the Claude Code SDK behavior by logging the bad value and falling back to defaults instead, so a single typo no longer renders the agent unusable.