### PR TITLE
fix: Rename effort config category to thought_level

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2119,7 +2119,7 @@ function buildConfigOptions(
       id: "effort",
       name: "Effort",
       description: "Available effort levels for this model",
-      category: "effort",
+      category: "thought_level",
       type: "select",
       currentValue: validEffort,
       options: effortOptions,


### PR DESCRIPTION
Uses the canonical version it should have been using.
