### PR TITLE
feat: add 'Default' option to effort level config

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1673,7 +1673,7 @@ export class ClaudeAcpAgent implements Agent {
         typeof newEffortOpt?.currentValue === "string" ? newEffortOpt.currentValue : undefined;
       if (newEffort !== currentEffort) {
         await session.query.applyFlagSettings({
-          effortLevel: newEffort as Settings["effortLevel"],
+          effortLevel: newEffort === "default" ? undefined : (newEffort as Settings["effortLevel"]),
         });
       }
 
@@ -1698,7 +1698,7 @@ export class ClaudeAcpAgent implements Agent {
       );
       if (configId === "effort") {
         await session.query.applyFlagSettings({
-          effortLevel: value as Settings["effortLevel"],
+          effortLevel: value === "default" ? undefined : (value as Settings["effortLevel"]),
         });
       }
     }
@@ -2017,7 +2017,7 @@ export class ClaudeAcpAgent implements Agent {
 
     // Apply the initial effort level to the SDK so it matches the UI default
     const initialEffort = configOptions.find((o) => o.id === "effort");
-    if (initialEffort && typeof initialEffort.currentValue === "string") {
+    if (initialEffort && typeof initialEffort.currentValue === "string" && initialEffort.currentValue !== "default") {
       await q.applyFlagSettings({
         effortLevel: initialEffort.currentValue as Settings["effortLevel"],
       });
@@ -2244,25 +2244,23 @@ function buildConfigOptions(
     : [];
 
   if (supportedLevels.length > 0) {
-    const effortOptions = supportedLevels.map((level) => ({
-      value: level,
-      name: level
-        .split(/[_-]/)
-        .map((part) => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
-        .join(" "),
-    }));
+    const effortOptions = [
+      { value: "default", name: "Default" },
+      ...supportedLevels.map((level) => ({
+        value: level,
+        name: level
+          .split(/[_-]/)
+          .map((part) => (part ? part.charAt(0).toUpperCase() + part.slice(1) : part))
+          .join(" "),
+      })),
+    ];
 
-    // Keep the current level if valid, otherwise prefer xhigh (Claude Code's
-    // recommended default for capable models), then high (the API default).
-    const includes = (l: string) => (supportedLevels as string[]).includes(l);
+    const includes = (l: string) =>
+      l === "default" || (supportedLevels as string[]).includes(l);
     const validEffort =
       currentEffortLevel && includes(currentEffortLevel)
         ? currentEffortLevel
-        : includes("xhigh")
-          ? "xhigh"
-          : includes("high")
-            ? "high"
-            : supportedLevels[0];
+        : "default";
 
     options.push({
       id: "effort",

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -65,8 +65,9 @@ const MOCK_CONFIG_OPTIONS = [
     description: "Available effort levels for this model",
     type: "select",
     category: "effort",
-    currentValue: "high",
+    currentValue: "default",
     options: [
+      { value: "default", name: "Default" },
       { value: "low", name: "Low" },
       { value: "medium", name: "Medium" },
       { value: "high", name: "High" },
@@ -483,8 +484,8 @@ describe("session config options", () => {
         (o: any) => o.id === "effort",
       );
       expect(effortOption).toBeDefined();
-      expect(effortOption.currentValue).toBe("high");
-      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: "high" });
+      expect(effortOption.currentValue).toBe("default");
+      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: undefined });
     });
 
     it("preserves effort in config_option_update when new model supports same level", async () => {
@@ -555,6 +556,21 @@ describe("session config options", () => {
       });
 
       expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: "low" });
+    });
+
+    it("calls applyFlagSettings with undefined effortLevel for 'default'", async () => {
+      // Set effort to a non-default value first
+      const session = (agent as unknown as { sessions: Record<string, any> }).sessions[SESSION_ID];
+      const effortOpt = session.configOptions.find((o: any) => o.id === "effort");
+      if (effortOpt) effortOpt.currentValue = "high";
+
+      await agent.setSessionConfigOption({
+        sessionId: SESSION_ID,
+        configId: "effort",
+        value: "default",
+      });
+
+      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: undefined });
     });
 
     it("updates effort currentValue in returned configOptions", async () => {
@@ -696,8 +712,8 @@ describe("session config options", () => {
 
       const effortOption = response.configOptions.find((o) => o.id === "effort");
       expect(effortOption).toBeDefined();
-      // No previous effort, so defaults to "high" (the API default)
-      expect(effortOption?.currentValue).toBe("high");
+      // No previous effort, so defaults to "default" (no effort override)
+      expect(effortOption?.currentValue).toBe("default");
     });
 
     it("clamps effort to valid value when new model has different supported levels", async () => {
@@ -731,10 +747,10 @@ describe("session config options", () => {
 
       const effortOption = response.configOptions.find((o) => o.id === "effort");
       expect(effortOption).toBeDefined();
-      // "max" is not in sonnet's levels, so should fall back to "high" (the API default)
-      expect(effortOption?.currentValue).toBe("high");
-      // SDK should be told about the clamped value
-      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: "high" });
+      // "max" is not in sonnet's levels, so should fall back to "default" (no effort override)
+      expect(effortOption?.currentValue).toBe("default");
+      // SDK should be told to clear the effort override
+      expect(applyFlagSettingsSpy).toHaveBeenCalledWith({ effortLevel: undefined });
     });
 
     it("preserves effort value when new model supports the same level", async () => {


### PR DESCRIPTION
Add a "Default" selection to the effort level config option, allowing users to let the SDK decide the effort level instead of forcing a specific level. When "default" is selected, applyFlagSettings is called with effortLevel: undefined, clearing any previous override.

Replaces the previous fallback logic (xhigh -> high -> supportedLevels[0]) with a simpler "default" fallback that lets the SDK use its own default.