### PR TITLE
Expose Claude skills through available commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.21.0",
-        "@anthropic-ai/claude-agent-sdk": "0.2.132",
+        "@anthropic-ai/claude-agent-sdk": "0.2.139",
         "zod": "^3.25.0 || ^4.0.0"
       },
       "bin": {
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.132.tgz",
-      "integrity": "sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.2.139.tgz",
+      "integrity": "sha512-9zmitYoxCQiQZsTUbm9IGC6VyZt70J3NLtkRQPQvFVfz7bKDrhlZZKzXmyl2XmqedXEIeQy2ACmwdjwzPIVIAw==",
       "license": "SEE LICENSE IN README.md",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.81.0",
@@ -53,23 +53,23 @@
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.132",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.132"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.2.139",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.2.139"
       },
       "peerDependencies": {
         "zod": "^4.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.132.tgz",
-      "integrity": "sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.2.139.tgz",
+      "integrity": "sha512-dnuO2E0x6o9GAk9iZZKlEd10h+0PQFdTfr5aQU4I0W+0ReKsFEoE9LAqfomS2EvLUQ9L62X0+n0iyZQmAVi1kw==",
       "cpu": [
         "arm64"
       ],
@@ -80,9 +80,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.132.tgz",
-      "integrity": "sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.2.139.tgz",
+      "integrity": "sha512-SXyldBIwpMHDXppPGObXZ1wjSSWf/YPgD6vK4nssIXarC/DtMRnAQ419Hb3q5MaBB29vSjOPKmG0MOkMltFR/A==",
       "cpu": [
         "x64"
       ],
@@ -93,9 +93,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.132.tgz",
-      "integrity": "sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.2.139.tgz",
+      "integrity": "sha512-qfnQ4SjEcq//iGAJkk25J6j4Tq+dvQe9wHks0dcaSdGOs2D96Teqrb358YJe+nke2DBKVUa9Y4ComW3aUBM29w==",
       "cpu": [
         "arm64"
       ],
@@ -106,9 +106,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.132.tgz",
-      "integrity": "sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.2.139.tgz",
+      "integrity": "sha512-gzMfit9t7Fiy5taZ+miAaP8ZmOMc+hv8Ov3UOXGwJunK6H+0F88ctBSnolDPMPQaS6s2WoMD0o8fhUbBudtMVw==",
       "cpu": [
         "arm64"
       ],
@@ -119,9 +119,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.132.tgz",
-      "integrity": "sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.2.139.tgz",
+      "integrity": "sha512-2Gqy5hV/MyObbwSyNhj5ha2cY5EZnUfDLvpEwR1eeOaU1yqnxzsdNzXWgHIyWQGKGNE2ICwgLYtt6AtOJGWpPg==",
       "cpu": [
         "x64"
       ],
@@ -132,9 +132,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.132.tgz",
-      "integrity": "sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.2.139.tgz",
+      "integrity": "sha512-Fg/aQs1vdyqLrNXqGa1i7/ODpGxP6ud/K/2AgVarLteg2Z3ZnrHPvPQ6iQmTGI8+BhxAZ141t4Dg0CWz3CoqCQ==",
       "cpu": [
         "x64"
       ],
@@ -145,9 +145,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.132.tgz",
-      "integrity": "sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.2.139.tgz",
+      "integrity": "sha512-HusAU/gSQ0G0AHU+Hj/ps0Tl5JaUF2nxkp+G42tU6hpnwLMOQMdLx/yqvSQnz4WSxggxiDFmYvMDLYAmuE9Qdg==",
       "cpu": [
         "arm64"
       ],
@@ -158,9 +158,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.2.132",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.132.tgz",
-      "integrity": "sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==",
+      "version": "0.2.139",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.2.139.tgz",
+      "integrity": "sha512-eJjbtLvEBJcTrl4WJhmhP7FYdTVvx/XtioifH7OEnCoxQozMHhOmA0X90csplIRpttX+jX2PqnE5j2FwU20eCw==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@agentclientprotocol/sdk": "0.21.0",
-    "@anthropic-ai/claude-agent-sdk": "0.2.132",
+    "@anthropic-ai/claude-agent-sdk": "0.2.139",
     "zod": "^3.25.0 || ^4.0.0"
   },
   "devDependencies": {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -849,6 +849,7 @@ export class ClaudeAcpAgent implements Agent {
               case "memory_recall":
               case "notification":
               case "api_retry":
+              case "permission_denied":
               case "mirror_error":
                 // Todo: process via status api: https://docs.claude.com/en/docs/claude-code/hooks#hook-output
                 break;


### PR DESCRIPTION
## Summary

Refs zed-industries/zed#55983.

This updates `@anthropic-ai/claude-agent-sdk` to `0.2.139`, whose `supportedCommands()` output includes Claude skills from `.claude/skills`. Since `claude-agent-acp` already publishes `supportedCommands()` as ACP `available_commands_update`, this makes Claude skills discoverable in ACP clients such as Zed's Agent Panel using Claude's native `/skill-name` convention.

The newer SDK also adds a `permission_denied` system message variant, so this PR handles it with the existing ignored system-status events to keep the message handling exhaustive.

## Testing

- `npm run build`
- `npm run test:run`
- `npm run check`
- `git diff --check`
- SDK behavior check with a temporary `.claude/skills/test-skill/SKILL.md`:
  - `query(...).supportedCommands()` returned `test-skill` with its description and argument hint.
- Manual Zed Agent Panel verification with a temporarily overlaid local `claude-agent-acp` package:
  - Opened `ai_coding_project_base`, which has project skills under `.claude/skills`.
  - Started an external `Claude Agent` thread.
  - Verified the composer placeholder says `/ for commands`.
  - Typed `/` and saw project skills in the completion menu, including `auto-verify`, `verify-task`, `ui-ux-pro-max`, `discover`, and `go`.
  - Did not submit a prompt.
  - Restored Zed's cached package afterward.

## Screenshots

I verified this visually in Zed's Agent Panel, but did not commit screenshots into the repo. The relevant visible state was the slash-command completion menu listing project skills such as `auto-verify`, `verify-task`, `ui-ux-pro-max`, `discover`, and `go` in a `Claude Agent` thread.

## Notes

This intentionally uses Claude Agent SDK's existing command discovery instead of adding a parallel skill scanner in the ACP adapter.

Release Notes:

- Improved Claude skill discoverability in ACP clients that expose slash command completions.
