### PR TITLE
fix: fall back to assembled assistant text when no stream deltas arrive

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -172,6 +172,17 @@ type Session = {
    *  back to emitting the assembled blocks (when the underlying SDK / model
    *  proxy never produced `content_block_delta` for them). */
   textStreamedMessageIds: Set<string>;
+  /** Keys of assembled text/thinking blocks the fallback path has already
+   *  forwarded this turn, used to dedup re-delivered blocks without dropping
+   *  genuinely new ones. A single assistant message id is frequently
+   *  delivered as several `assistant` messages, each carrying a *different*
+   *  subset of content blocks (e.g. an empty `thinking` block, then the real
+   *  `text` block); deduping at message-id granularity would emit the first
+   *  block, flag the id, then silently drop the later text. Keying on the
+   *  block content instead lets distinct blocks that share an id all through
+   *  while still collapsing identical re-deliveries (incremental + consolidated
+   *  messages, or the same message delivered twice). */
+  fallbackEmittedBlockKeys: Set<string>;
   /** Id of the assistant message currently being streamed via `stream_event`
    *  partial messages, captured at `message_start` so subsequent
    *  `content_block_delta` events can record their parent into
@@ -755,10 +766,12 @@ export class ClaudeAcpAgent implements Agent {
       cachedWriteTokens: 0,
     };
 
-    // Assistant message ids are turn-scoped — clear before a new turn so the
-    // set doesn't grow unboundedly over a long-lived session, and so that an
-    // id reused across turns (uncommon but possible) is re-evaluated.
+    // Assistant message ids and fallback block keys are turn-scoped — clear
+    // before a new turn so the sets don't grow unboundedly over a long-lived
+    // session, and so that an id reused across turns (uncommon but possible)
+    // is re-evaluated.
     session.textStreamedMessageIds.clear();
+    session.fallbackEmittedBlockKeys.clear();
     session.currentStreamingMessageId = undefined;
 
     let lastAssistantTotalUsage: number | null = null;
@@ -1270,49 +1283,61 @@ export class ClaudeAcpAgent implements Agent {
             // (e.g. because the underlying model proxy returned the response
             // as a single non-streamed block, which is common with OpenAI-
             // compatible gateways translating to the Anthropic protocol), the
-            // delta path emitted nothing — falling through with the filter in
-            // place would drop the assistant's final text on the floor while
-            // still returning `stopReason: "end_turn"`. Detect that case via
+            // delta path emitted nothing — filtering the assembled blocks out
+            // would drop the assistant's final text on the floor while still
+            // returning `stopReason: "end_turn"`. Detect that case via
             // `textStreamedMessageIds` and emit the assembled blocks as a
             // fallback.
+            //
+            // The fallback dedup must be per content block, not per message
+            // id: such gateways frequently deliver one assistant response as
+            // several `assistant` messages that *share a message id* but each
+            // carry a *different* block (e.g. an empty `thinking` block, then
+            // the real `text` block). Flagging the whole id after the first
+            // block would emit that block, then silently drop the real text
+            // arriving under the same id. So we key the dedup on the block
+            // contents, which lets distinct blocks through while still
+            // collapsing identical re-deliveries (an incremental block
+            // followed by a consolidated message, or the same message
+            // delivered twice).
             const assistantMessageId =
               message.type === "assistant" ? message.message.id : undefined;
-            const textAlreadyStreamed =
+            const liveStreamed =
               !!assistantMessageId && session.textStreamedMessageIds.has(assistantMessageId);
 
-            if (
-              message.type === "assistant" &&
-              !textAlreadyStreamed &&
-              Array.isArray(message.message.content) &&
-              message.message.content.some(
-                (item) => item.type === "text" || item.type === "thinking",
-              )
-            ) {
+            let emittedFallbackBlock = false;
+            const content =
+              message.type === "assistant"
+                ? message.message.content.filter((item) => {
+                    if (item.type !== "text" && item.type !== "thinking") {
+                      return true;
+                    }
+                    // Already delivered live via streaming deltas — drop the
+                    // assembled copy to avoid duplication.
+                    if (liveStreamed) {
+                      return false;
+                    }
+                    // Fallback path: emit each assembled block once, keyed on
+                    // its contents so re-delivered blocks dedup but distinct
+                    // blocks sharing a message id are all forwarded.
+                    const blockText = item.type === "text" ? item.text : item.thinking;
+                    const key = `${assistantMessageId ?? "<unknown>"}\u0000${item.type}\u0000${blockText}`;
+                    if (session.fallbackEmittedBlockKeys.has(key)) {
+                      return false;
+                    }
+                    session.fallbackEmittedBlockKeys.add(key);
+                    emittedFallbackBlock = true;
+                    return true;
+                  })
+                : message.message.content;
+
+            if (emittedFallbackBlock) {
               this.logger.log(
                 `[claude-agent-acp] No streamed text/thinking deltas seen for ` +
                   `assistant message ${assistantMessageId ?? "<unknown>"}; ` +
                   `emitting assembled blocks as fallback.`,
               );
-              // After this fallback emits, mark the id so a duplicate
-              // `assistant` delivery of the same message doesn't re-emit the
-              // same text/thinking blocks. Mirrors the dedupe semantics that
-              // streaming-emitted ids already have.
-              if (assistantMessageId) {
-                session.textStreamedMessageIds.add(assistantMessageId);
-              }
             }
-
-            const content =
-              message.type === "assistant"
-                ? message.message.content.filter((item) => {
-                    if (item.type === "text" || item.type === "thinking") {
-                      // Keep only when the stream_event path didn't already
-                      // emit chunks for this message id.
-                      return !textAlreadyStreamed;
-                    }
-                    return true;
-                  })
-                : message.message.content;
 
             for (const notification of toAcpNotifications(
               content,
@@ -2338,6 +2363,7 @@ export class ClaudeAcpAgent implements Agent {
         inferContextWindowFromModel(models.currentModelId) ?? DEFAULT_CONTEXT_WINDOW,
       taskState,
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
 
     return {

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -165,6 +165,18 @@ type Session = {
   /** Accumulated task list for the session, keyed by task ID. Task IDs are
    *  per-session, so this state must not be shared across sessions. */
   taskState: TaskState;
+  /** Assistant message ids whose text/thinking content was already emitted as
+   *  `agent_message_chunk` / `agent_thought_chunk` via `stream_event` partial
+   *  messages. Used by the top-level `assistant` case to decide whether to
+   *  skip text/thinking blocks (the default, when streaming worked) or fall
+   *  back to emitting the assembled blocks (when the underlying SDK / model
+   *  proxy never produced `content_block_delta` for them). */
+  textStreamedMessageIds: Set<string>;
+  /** Id of the assistant message currently being streamed via `stream_event`
+   *  partial messages, captured at `message_start` so subsequent
+   *  `content_block_delta` events can record their parent into
+   *  `textStreamedMessageIds`. */
+  currentStreamingMessageId?: string;
 };
 
 /** Compute a stable fingerprint of the session-defining params so we can
@@ -743,6 +755,12 @@ export class ClaudeAcpAgent implements Agent {
       cachedWriteTokens: 0,
     };
 
+    // Assistant message ids are turn-scoped — clear before a new turn so the
+    // set doesn't grow unboundedly over a long-lived session, and so that an
+    // id reused across turns (uncommon but possible) is re-evaluated.
+    session.textStreamedMessageIds.clear();
+    session.currentStreamingMessageId = undefined;
+
     let lastAssistantTotalUsage: number | null = null;
     let lastAssistantUsage: UsageSnapshot | null = null;
     let lastAssistantModel: string | null = null;
@@ -1056,6 +1074,23 @@ export class ClaudeAcpAgent implements Agent {
             break;
           }
           case "stream_event": {
+            // Track which assistant message ids have produced streamed text /
+            // thinking deltas so the `assistant` case below can fall back to
+            // emitting the assembled content when streaming didn't (e.g. when
+            // the SDK is talking to a model proxy that never produces
+            // `content_block_delta` events for the second model call in a
+            // tool-use loop).
+            if (message.event.type === "message_start") {
+              session.currentStreamingMessageId = message.event.message.id;
+            } else if (
+              message.event.type === "content_block_delta" &&
+              (message.event.delta.type === "text_delta" ||
+                message.event.delta.type === "thinking_delta") &&
+              session.currentStreamingMessageId
+            ) {
+              session.textStreamedMessageIds.add(session.currentStreamingMessageId);
+            }
+
             if (
               message.parent_tool_use_id === null &&
               (message.event.type === "message_start" || message.event.type === "message_delta")
@@ -1227,12 +1262,56 @@ export class ClaudeAcpAgent implements Agent {
               throw RequestError.authRequired();
             }
 
+            // Text and thinking blocks are normally emitted from the
+            // `stream_event` case above as `content_block_delta` arrives,
+            // so the assembled message replays them here. We skip them in
+            // that case to avoid duplication. However, if streaming never
+            // produced any text/thinking delta for this assistant message
+            // (e.g. because the underlying model proxy returned the response
+            // as a single non-streamed block, which is common with OpenAI-
+            // compatible gateways translating to the Anthropic protocol), the
+            // delta path emitted nothing — falling through with the filter in
+            // place would drop the assistant's final text on the floor while
+            // still returning `stopReason: "end_turn"`. Detect that case via
+            // `textStreamedMessageIds` and emit the assembled blocks as a
+            // fallback.
+            const assistantMessageId =
+              message.type === "assistant" ? message.message.id : undefined;
+            const textAlreadyStreamed =
+              !!assistantMessageId && session.textStreamedMessageIds.has(assistantMessageId);
+
+            if (
+              message.type === "assistant" &&
+              !textAlreadyStreamed &&
+              Array.isArray(message.message.content) &&
+              message.message.content.some(
+                (item) => item.type === "text" || item.type === "thinking",
+              )
+            ) {
+              this.logger.log(
+                `[claude-agent-acp] No streamed text/thinking deltas seen for ` +
+                  `assistant message ${assistantMessageId ?? "<unknown>"}; ` +
+                  `emitting assembled blocks as fallback.`,
+              );
+              // After this fallback emits, mark the id so a duplicate
+              // `assistant` delivery of the same message doesn't re-emit the
+              // same text/thinking blocks. Mirrors the dedupe semantics that
+              // streaming-emitted ids already have.
+              if (assistantMessageId) {
+                session.textStreamedMessageIds.add(assistantMessageId);
+              }
+            }
+
             const content =
               message.type === "assistant"
-                ? // Handled by stream events above
-                  message.message.content.filter(
-                    (item) => !["text", "thinking"].includes(item.type),
-                  )
+                ? message.message.content.filter((item) => {
+                    if (item.type === "text" || item.type === "thinking") {
+                      // Keep only when the stream_event path didn't already
+                      // emit chunks for this message id.
+                      return !textAlreadyStreamed;
+                    }
+                    return true;
+                  })
                 : message.message.content;
 
             for (const notification of toAcpNotifications(
@@ -2258,6 +2337,7 @@ export class ClaudeAcpAgent implements Agent {
       contextWindowSize:
         inferContextWindowFromModel(models.currentModelId) ?? DEFAULT_CONTEXT_WINDOW,
       taskState,
+      textStreamedMessageIds: new Set<string>(),
     };
 
     return {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1545,6 +1545,7 @@ describe("stop reason propagation", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -1690,6 +1691,7 @@ describe("stop reason propagation", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
 
     const response = await agent.prompt({
@@ -1863,6 +1865,7 @@ describe("assistant text fallback when streaming yields no text deltas", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -1892,6 +1895,13 @@ describe("assistant text fallback when streaming yields no text deltas", () => {
   }
 
   function makeAssistantMessage(messageId: string, text: string) {
+    return makeAssistantMessageWithBlocks(messageId, [{ type: "text", text }]);
+  }
+
+  // Same as makeAssistantMessage but with arbitrary content blocks, so tests
+  // can reproduce gateways that split a single response (one message id) into
+  // several `assistant` messages each carrying a different block.
+  function makeAssistantMessageWithBlocks(messageId: string, content: any[]) {
     return {
       type: "assistant" as const,
       parent_tool_use_id: null,
@@ -1902,7 +1912,7 @@ describe("assistant text fallback when streaming yields no text deltas", () => {
         type: "message" as const,
         role: "assistant" as const,
         model: "claude-test",
-        content: [{ type: "text", text }],
+        content,
         stop_reason: "end_turn",
         stop_sequence: null,
         usage: {
@@ -2081,6 +2091,126 @@ describe("assistant text fallback when streaming yields no text deltas", () => {
     // Two turns each fallback-emit once.
     expect(textChunks.length).toBe(2);
   });
+
+  it("emits the text block when it arrives in a later same-id message than the thinking block", async () => {
+    // Production regression (OpenAI-compatible gpt-5 gateway): a single
+    // assistant response (one message id) is delivered as *separate*
+    // `assistant` messages — an empty `thinking` block first, then the real
+    // `text` block — both sharing the same id and neither streamed via
+    // content_block_delta. Deduping at message-id granularity flagged the id
+    // on the thinking block and then dropped the text, so the client saw the
+    // fallback fire but received an empty answer. The fallback must key on the
+    // block contents so the later text block is still emitted.
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "resp_split_blocks";
+    const finalText = "=== Ticket Review Summary === approved";
+    injectSession(agent, [
+      makeAssistantMessageWithBlocks(messageId, [
+        { type: "thinking", thinking: "", signature: "sig" },
+      ]),
+      makeAssistantMessageWithBlocks(messageId, [{ type: "text", text: finalText }]),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const textChunks = notifications
+      .map((n) => n.update)
+      .filter(
+        (u) =>
+          u.sessionUpdate === "agent_message_chunk" &&
+          u.content.type === "text" &&
+          u.content.text === finalText,
+      );
+    expect(textChunks.length).toBe(1);
+  });
+
+  it("emits distinct text blocks that share a message id", async () => {
+    // A gateway may split a multi-block answer (thinking + text + a second
+    // text) across same-id messages. Every distinct text block must reach the
+    // client exactly once.
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "resp_multi_text";
+    const firstText = "我先直接执行审批并返回工单结果。";
+    const secondText = "Ticket approved.";
+    injectSession(agent, [
+      makeAssistantMessageWithBlocks(messageId, [
+        { type: "thinking", thinking: "considering options", signature: "sig" },
+      ]),
+      makeAssistantMessageWithBlocks(messageId, [{ type: "text", text: firstText }]),
+      makeAssistantMessageWithBlocks(messageId, [{ type: "text", text: secondText }]),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const updates = notifications.map((n) => n.update);
+    const firstChunks = updates.filter(
+      (u) =>
+        u.sessionUpdate === "agent_message_chunk" &&
+        u.content.type === "text" &&
+        u.content.text === firstText,
+    );
+    const secondChunks = updates.filter(
+      (u) =>
+        u.sessionUpdate === "agent_message_chunk" &&
+        u.content.type === "text" &&
+        u.content.text === secondText,
+    );
+    expect(firstChunks.length).toBe(1);
+    expect(secondChunks.length).toBe(1);
+  });
+
+  it("does not duplicate text when an incremental block is followed by a consolidated message", async () => {
+    // Some gateways deliver an incremental per-block `assistant` message and
+    // then a consolidated `assistant` message (same id) that repeats that
+    // block alongside others. The repeated block must not be emitted twice.
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "resp_consolidated";
+    const thinking = "step-by-step reasoning";
+    const finalText = "the answer";
+    injectSession(agent, [
+      makeAssistantMessageWithBlocks(messageId, [{ type: "text", text: finalText }]),
+      makeAssistantMessageWithBlocks(messageId, [
+        { type: "thinking", thinking, signature: "sig" },
+        { type: "text", text: finalText },
+      ]),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const updates = notifications.map((n) => n.update);
+    const textChunks = updates.filter(
+      (u) =>
+        u.sessionUpdate === "agent_message_chunk" &&
+        u.content.type === "text" &&
+        u.content.text === finalText,
+    );
+    const thoughtChunks = updates.filter(
+      (u) =>
+        u.sessionUpdate === "agent_thought_chunk" &&
+        u.content.type === "text" &&
+        u.content.text === thinking,
+    );
+    expect(textChunks.length).toBe(1);
+    expect(thoughtChunks.length).toBe(1);
+  });
 });
 
 describe("session/close", () => {
@@ -2125,6 +2255,7 @@ describe("session/close", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -2210,6 +2341,7 @@ describe("session/delete", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -2312,6 +2444,7 @@ describe("getOrCreateSession param change detection", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -2548,6 +2681,7 @@ describe("usage_update computation", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -3449,6 +3583,7 @@ describe("emitRawSDKMessages", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -3678,6 +3813,7 @@ describe("result origin handling", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -3854,6 +3990,7 @@ describe("memory_recall handling", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
   }
 
@@ -4085,6 +4222,7 @@ describe("post-error recovery", () => {
       contextWindowSize: 200000,
       taskState: new Map(),
       textStreamedMessageIds: new Set<string>(),
+      fallbackEmittedBlockKeys: new Set<string>(),
     };
     return { interrupt };
   }

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1544,6 +1544,7 @@ describe("stop reason propagation", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
   }
 
@@ -1688,6 +1689,7 @@ describe("stop reason propagation", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
 
     const response = await agent.prompt({
@@ -1806,6 +1808,281 @@ describe("stop reason propagation", () => {
   });
 });
 
+describe("assistant text fallback when streaming yields no text deltas", () => {
+  function createCapturingAgent() {
+    const notifications: SessionNotification[] = [];
+    const mockClient = {
+      sessionUpdate: async (n: SessionNotification) => {
+        notifications.push(n);
+      },
+      extNotification: async () => {},
+    } as unknown as AgentSideConnection;
+    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+    return { agent, notifications };
+  }
+
+  function injectSession(agent: ClaudeAcpAgent, messages: any[]) {
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage, done } = await iter.next();
+      if (!done && userMessage) {
+        yield {
+          type: "user",
+          message: userMessage.message,
+          parent_tool_use_id: null,
+          uuid: userMessage.uuid,
+          session_id: "test-session",
+          isReplay: true,
+        };
+      }
+      yield* messages;
+    }
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+      abortController: new AbortController(),
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
+    };
+  }
+
+  function makeResult() {
+    return {
+      type: "result" as const,
+      subtype: "success" as const,
+      stop_reason: null,
+      is_error: false,
+      result: "",
+      errors: [],
+      duration_ms: 0,
+      duration_api_ms: 0,
+      num_turns: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: randomUUID(),
+      session_id: "test-session",
+    };
+  }
+
+  function makeAssistantMessage(messageId: string, text: string) {
+    return {
+      type: "assistant" as const,
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+      session_id: "test-session",
+      message: {
+        id: messageId,
+        type: "message" as const,
+        role: "assistant" as const,
+        model: "claude-test",
+        content: [{ type: "text", text }],
+        stop_reason: "end_turn",
+        stop_sequence: null,
+        usage: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+    };
+  }
+
+  it("emits the assembled text when no content_block_delta was streamed", async () => {
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "msg_no_stream";
+    const finalText = "final answer never streamed";
+    injectSession(agent, [
+      makeAssistantMessage(messageId, finalText),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const textChunks = notifications
+      .map((n) => n.update)
+      .filter(
+        (u) =>
+          u.sessionUpdate === "agent_message_chunk" &&
+          u.content.type === "text" &&
+          u.content.text === finalText,
+      );
+    expect(textChunks.length).toBe(1);
+  });
+
+  it("does not re-emit text already streamed via content_block_delta", async () => {
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "msg_streamed";
+    const streamedText = "streamed answer";
+    injectSession(agent, [
+      {
+        type: "stream_event",
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+        event: {
+          type: "message_start",
+          message: {
+            id: messageId,
+            type: "message",
+            role: "assistant",
+            model: "claude-test",
+            content: [],
+            stop_reason: null,
+            stop_sequence: null,
+            usage: {
+              input_tokens: 0,
+              output_tokens: 0,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          },
+        },
+      },
+      {
+        type: "stream_event",
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+        event: {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text: streamedText },
+        },
+      },
+      makeAssistantMessage(messageId, streamedText),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const textChunks = notifications
+      .map((n) => n.update)
+      .filter(
+        (u) =>
+          u.sessionUpdate === "agent_message_chunk" &&
+          u.content.type === "text" &&
+          u.content.text === streamedText,
+      );
+    // Only the streamed content_block_delta should produce a chunk; the
+    // assembled message must not duplicate it.
+    expect(textChunks.length).toBe(1);
+  });
+
+  it("fallback emits exactly once when the same assistant message is delivered twice", async () => {
+    // Regression test: the SDK occasionally delivers the same assembled
+    // assistant message twice (observed in production logs). Without
+    // recording the id into `textStreamedMessageIds` after the first
+    // fallback emit, the second delivery would re-fire the fallback and
+    // ACP clients would see duplicate text chunks. After the dedupe fix
+    // the second delivery must be a no-op.
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "msg_delivered_twice";
+    const finalText = "final answer delivered twice";
+    injectSession(agent, [
+      makeAssistantMessage(messageId, finalText),
+      makeAssistantMessage(messageId, finalText),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "go" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
+    const textChunks = notifications
+      .map((n) => n.update)
+      .filter(
+        (u) =>
+          u.sessionUpdate === "agent_message_chunk" &&
+          u.content.type === "text" &&
+          u.content.text === finalText,
+      );
+    expect(textChunks.length).toBe(1);
+  });
+
+  it("textStreamedMessageIds is cleared at the start of each new turn", async () => {
+    // Regression test: assistant message ids are turn-scoped. Without
+    // per-turn clear, the set would accumulate over the session's lifetime
+    // and a (rare) reuse of an id across turns would be misclassified as
+    // "already streamed", silently dropping the fallback emit. The two
+    // turns below use the same messageId; both should fallback-emit
+    // exactly once because the set is reset on each `prompt()` entry.
+    const { agent, notifications } = createCapturingAgent();
+    const messageId = "msg_reused_across_turns";
+    const finalText = "answer for both turns";
+    injectSession(agent, [
+      makeAssistantMessage(messageId, finalText),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+      makeAssistantMessage(messageId, finalText),
+      makeResult(),
+      { type: "system", subtype: "session_state_changed", state: "idle" },
+    ]);
+
+    const first = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "turn 1" }],
+    });
+    const second = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "turn 2" }],
+    });
+
+    expect(first.stopReason).toBe("end_turn");
+    expect(second.stopReason).toBe("end_turn");
+    const textChunks = notifications
+      .map((n) => n.update)
+      .filter(
+        (u) =>
+          u.sessionUpdate === "agent_message_chunk" &&
+          u.content.type === "text" &&
+          u.content.text === finalText,
+      );
+    // Two turns each fallback-emit once.
+    expect(textChunks.length).toBe(2);
+  });
+});
+
 describe("session/close", () => {
   function createMockAgent() {
     const mockClient = {
@@ -1847,6 +2124,7 @@ describe("session/close", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -1931,6 +2209,7 @@ describe("session/delete", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -2032,6 +2311,7 @@ describe("getOrCreateSession param change detection", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
     return agent.sessions[sessionId]!;
   }
@@ -2267,6 +2547,7 @@ describe("usage_update computation", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
   }
 
@@ -3167,6 +3448,7 @@ describe("emitRawSDKMessages", () => {
       emitRawSDKMessages,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
   }
 
@@ -3395,6 +3677,7 @@ describe("result origin handling", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
   }
 
@@ -3570,6 +3853,7 @@ describe("memory_recall handling", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
   }
 
@@ -3800,6 +4084,7 @@ describe("post-error recovery", () => {
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
+      textStreamedMessageIds: new Set<string>(),
     };
     return { interrupt };
   }


### PR DESCRIPTION
## Background

When the underlying Claude Agent SDK talks to an Anthropic-protocol gateway that does **not** preserve `content_block_delta` events for some responses (common with OpenAI-compatible gateways translating to the Anthropic protocol — e.g. internal model gateways, LiteLLM-based proxies, custom Bedrock/Vertex shims), the ACP adapter silently drops the final assistant text:

1. The model produces a normal turn ending with `stop_reason: \"end_turn\"\`.
2. The SDK forwards a fully assembled \`assistant\` message containing a \`text\` block.
3. \`prompt()\` in \`acp-agent.ts\` filters that \`text\` block out, with the comment _\"Handled by stream events above\"_:

\`\`\`ts
const content =
  message.type === \"assistant\"
    ? // Handled by stream events above
      message.message.content.filter(
        (item) => ![\"text\", \"thinking\"].includes(item.type),
      )
    : message.message.content;
\`\`\`

4. But because the gateway never emitted \`content_block_delta\` for the text, the \`stream_event\` path never produced an \`agent_message_chunk\` either. The ACP client receives only \`tool_call\` updates and \`result.stopReason: \"end_turn\"\` — no \`agent_message_chunk\` ever arrives.

The client UI is left displaying tool progress with an empty final answer, while the underlying Claude Code session log shows the text content was produced normally.

## Repro

* Drive the SDK against a gateway that returns one or more model calls as a single non-streamed block (most commonly the follow-up call that consumes a tool_result).
* Ask the agent something that triggers \`tool_use → tool_result → final text\`.
* Observe in the ACP client: tool_call progress arrives, the prompt RPC returns \`stopReason: \"end_turn\"\`, and the final text never shows up.

## Fix

Track which assistant message ids have actually produced streamed text/thinking deltas (\`textStreamedMessageIds\` on \`Session\`, populated from \`message_start\` + \`content_block_delta\` in the \`stream_event\` case). In the \`assistant\` case, keep the existing filter when the id is in that set, and fall back to forwarding the assembled \`text\` / \`thinking\` blocks as \`agent_message_chunk\` / \`agent_thought_chunk\` when it isn't.

Same dedupe pattern as \`toolUseCache\` already uses for \`tool_use\` blocks (first encounter via stream → \`tool_call\`, second encounter via assembled message → \`tool_call_update\`).

A single \`logger.log\` line is emitted on the fallback path so operators have a hard signal when this fires.

## Production evidence

Deployed to a Lark/Feishu bot that uses an internal OpenAI-style gateway (gpt-5.4 model fronted via Anthropic protocol). The fallback fires regularly in real traffic — log excerpt from the first few minutes after deploy:

\`\`\`
[claude-agent-acp] No streamed text/thinking deltas seen for assistant message resp_049906868815d358006a05a8f2b7e4819398e68b896940fd58; emitting assembled blocks as fallback.
[claude-agent-acp] No streamed text/thinking deltas seen for assistant message resp_0be8b8386e3f41a9006a05a8fd865481949773a185cd1676ef; emitting assembled blocks as fallback.
[claude-agent-acp] No streamed text/thinking deltas seen for assistant message resp_0be8b8386e3f41a9006a05a8fd865481949773a185cd1676ef; emitting assembled blocks as fallback.
[claude-agent-acp] No streamed text/thinking deltas seen for assistant message resp_068c4787db729814006a05a95539dc81948d4291821926b50a; emitting assembled blocks as fallback.
\`\`\`

Each of those would have been an empty final answer before this fix. After the fix all four sessions delivered the assistant's text correctly to the ACP client.

## Test plan

- [x] \`npm run test:run\` — 257 passed, 13 skipped (255 existing + 2 new)
- [x] \`npm run check\` (lint + prettier) — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] Two new tests in \`src/tests/acp-agent.test.ts\` covering both branches:
  - _emits the assembled text when no \`content_block_delta\` was streamed_
  - _does not re-emit text already streamed via \`content_block_delta\`_
- [x] Verified in production against an OpenAI-style gateway (see logs above)

## Notes / open questions

- The duplicate fallback log for \`resp_0be8b8...\` in the production output is benign for that case (Lark side accumulator is idempotent against the same assembled text arriving twice). It would be reasonable to also record the message id into \`textStreamedMessageIds\` _after_ the fallback emits, to make the fallback path itself idempotent against duplicate \`assistant\` deliveries. Happy to add that in a follow-up commit if you prefer; left out of this change to keep the diff focused on the original bug.
- A second appealing direction would be to switch \`toolUseCache\`'s implementation to a \`Set<id>\` once we no longer need the input snapshot — currently the only thing keeping it as a map is the secondary \`tool_call_update\` payload. Out of scope here.

Made with [Cursor](https://cursor.com)