### PR TITLE
fix: load credential error for bedrock gateway

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2164,7 +2164,7 @@ function createEnvForGateway(request?: GatewayAuthRequest) {
   if (request.methodId === "gateway-bedrock") {
     return {
       CLAUDE_CODE_USE_BEDROCK: "1",
-      AWS_BEARER_TOKEN_BEDROCK: "",
+      AWS_BEARER_TOKEN_BEDROCK: " ", // Must be non-empty to bypass pass configuration check
       ANTHROPIC_BEDROCK_BASE_URL: request._meta.gateway.baseUrl,
       ANTHROPIC_CUSTOM_HEADERS: customHeaders,
     };

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -154,7 +154,7 @@ describe("authorization", () => {
         options: expect.objectContaining({
           env: expect.objectContaining({
             CLAUDE_CODE_USE_BEDROCK: "1",
-            AWS_BEARER_TOKEN_BEDROCK: "",
+            AWS_BEARER_TOKEN_BEDROCK: " ",
             ANTHROPIC_BEDROCK_BASE_URL: "https://gateway.example",
             ANTHROPIC_CUSTOM_HEADERS: "custom-header: test",
           }),


### PR DESCRIPTION
Sometimes leads to long initialization and error if AWS_BEARER_TOKEN_BEDROCK:
Could not load credentials from any providers
