### PR TITLE
chore: tighten local-command-stdout handler comment and pass full options

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1125,7 +1125,6 @@ export class ClaudeAcpAgent implements Agent {
               typeof message.message.content === "string" &&
               message.message.content.includes("<local-command-stdout>")
             ) {
-              this.logger.log(message.message.content);
               const stripped = stripLocalCommandMetadata(message.message.content);
               if (typeof stripped === "string") {
                 for (const notification of toAcpNotifications(
@@ -1144,6 +1143,8 @@ export class ClaudeAcpAgent implements Agent {
                 )) {
                   await this.client.sessionUpdate(notification);
                 }
+              } else {
+                this.logger.log(message.message.content);
               }
               break;
             }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1116,21 +1116,11 @@ export class ClaudeAcpAgent implements Agent {
               }
             }
 
-            // Slash commands like /compact can generate invalid output... doesn't match
-            // their own docs: https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-slash-commands#%2Fcompact-compact-conversation-history
-            //
-            // Strip local-command marker tags from the content and render whatever
-            // real prose remains, so that custom slash commands / user-defined
-            // skills (whose bodies arrive wrapped in <command-*> / <local-command-stdout>
-            // markers) and built-in commands that emit textual output reach the UI.
-            // Previously this branch dropped every message containing a stdout
-            // marker, which silently swallowed every successful skill invocation
-            // and any built-in command that emits output through these tags.
-            // strip-and-render is safe because stripLocalCommandMetadata returns
-            // null when nothing renderable remains (e.g. pure-marker /compact
-            // payloads), so the no-render no-op path is preserved for those cases.
-            //
-            // Refs zed-industries/claude-code-acp#624, #642.
+            // Strip <command-*>/<local-command-stdout> markers and render any
+            // remaining prose. Skill bodies and built-in slash commands (e.g.
+            // /usage, /status, /model) arrive wrapped in these tags; pure-marker
+            // payloads (e.g. /compact's malformed output) strip to null and are
+            // skipped. Mirrors the replay path at replaySessionHistory.
             if (
               typeof message.message.content === "string" &&
               message.message.content.includes("<local-command-stdout>")
@@ -1145,6 +1135,12 @@ export class ClaudeAcpAgent implements Agent {
                   this.toolUseCache,
                   this.client,
                   this.logger,
+                  {
+                    clientCapabilities: this.clientCapabilities,
+                    parentToolUseId: message.parent_tool_use_id,
+                    cwd: session.cwd,
+                    taskState: session.taskState,
+                  },
                 )) {
                   await this.client.sessionUpdate(notification);
                 }


### PR DESCRIPTION
## Summary

Follow-up cleanup to #649. Two small changes:

- **Tighten the comment block** above the marker-strip branch in `acp-agent.ts:1119`. The original 15-line block restated history that already lives in the PR description; replaced with a 5-line "what this does, and why the no-op case is preserved" comment that points at the replay path for parallel context.
- **Forward `clientCapabilities`, `parentToolUseId`, `cwd`, and `taskState`** to `toAcpNotifications` so the new strip-and-render call matches the sibling call below it at `acp-agent.ts:1192`. Without these the rendered output loses threading under a wrapping tool use and skips terminal-output detection.
- **Only log the raw payload when nothing renders** — previously every marker-containing message was logged AND rendered. Now we render the stripped prose if anything remains, and fall back to logging only the pure-marker case (e.g. `/compact`).

## Test plan

- [x] `npm run check` (lint + format) — passes
- [x] `npm run build` (tsc) — passes
- [x] `stripLocalCommandMetadata` unit tests — 8 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)