### PR TITLE
no-op ping keep-alive events

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3207,7 +3207,11 @@ export function streamEventToAcpNotifications(
           taskState: options?.taskState,
         },
       );
-    // No content
+    // No content. `ping` is a Messages-API keep-alive event that the SDK's
+    // `BetaRawMessageStreamEvent` union doesn't include even though the
+    // wire format emits it; the `as never` cast lets us no-op it here
+    // instead of letting it fall through to `unreachable`.
+    case "ping" as never:
     case "message_start":
     case "message_delta":
     case "message_stop":

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -32,6 +32,7 @@ import {
   ClaudeAcpAgent,
   claudeCliPath,
   describeAlwaysAllow,
+  streamEventToAcpNotifications,
   type SDKMessageFilter,
 } from "../acp-agent.js";
 import { Pushable } from "../utils.js";
@@ -3870,5 +3871,40 @@ describe("post-error recovery", () => {
     await expect(pendingA).resolves.toBe(true);
     await expect(pendingB).resolves.toBe(true);
     expect(session.pendingMessages.size).toBe(0);
+  });
+});
+
+describe("streamEventToAcpNotifications", () => {
+  it("treats `ping` keep-alive events as no-ops without logging to stderr", () => {
+    const errors: unknown[][] = [];
+    const logger = {
+      log: () => {},
+      error: (...args: unknown[]) => {
+        errors.push(args);
+      },
+    };
+    const pingMessage = {
+      type: "stream_event",
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+      session_id: "test-session",
+      // The SDK's typed `BetaRawMessageStreamEvent` union doesn't include
+      // `ping`, but the API emits it on the wire and the SDK passes it
+      // through. Cast through `unknown` to feed the realistic runtime shape.
+      event: { type: "ping" } as unknown,
+    } as Parameters<typeof streamEventToAcpNotifications>[0];
+
+    const result = streamEventToAcpNotifications(
+      pingMessage,
+      "test-session",
+      {},
+      { sessionUpdate: async () => {} } as unknown as Parameters<
+        typeof streamEventToAcpNotifications
+      >[3],
+      logger,
+    );
+
+    expect(result).toEqual([]);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
AI disclaimer: I noticed `ping` events spamming the agent-shell Notices buffer and used Claude to confirm the mechanism, locate the missing case, and draft the fix and test. I reviewed the diff, ran the full lint / type-check / test gauntlet locally, and vouch for the change.

## Summary

`streamEventToAcpNotifications` exhaustively switches on `event.type` against the SDK's `BetaRawMessageStreamEvent` union and falls through to `unreachable` for anything else. The Anthropic Messages streaming API also emits `ping` keep-alive events ([docs](https://docs.anthropic.com/en/api/messages-streaming#ping-events)) which aren't listed in that union but do reach this function at runtime. Since #173 made `unreachable` log rather than throw, every ping now writes `Unexpected case: {"type":"ping"}` to stderr.

## Symptom

In ACP clients that surface agent stderr, each `ping` lands as a "Notice" entry next to the agent's normal output. With long-running turns this produces multiple stderr lines per minute of generation. Example from an agent-shell debug capture:

```
▶ Notices

Unexpected case: {"type":"ping"}
Unexpected case: {"type":"ping"}
```

## Fix

Add `case "ping" as never:` to the existing no-content branch in `streamEventToAcpNotifications`. The `as never` cast is required because `BetaRawMessageStreamEvent` is closed at the type level even though the wire format emits `ping`. Comment placed above the no-content group so ESLint's `no-fallthrough` rule doesn't see it as breaking case adjacency.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] `npm run test:run` — 290 passed / 13 skipped (integration-gated)
- [x] New unit test in `src/tests/acp-agent.test.ts` covers `streamEventToAcpNotifications` directly: feeds a synthetic `ping` stream_event and asserts both `[]` return and that the logger's `error` channel is never touched.
