### PR TITLE
fix: Don't expose /clear in commands

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2672,6 +2672,7 @@ async function getAvailableModels(
 
 function getAvailableSlashCommands(commands: SlashCommand[]): AvailableCommand[] {
   const UNSUPPORTED_COMMANDS = [
+    "clear",
     "cost",
     "keybindings-help",
     "login",


### PR DESCRIPTION
Closes #657

This probably isn't the desired fix, but as /clear creates a new
session, it breaks a lot of guarantees on ACP's usage of session ids we
want to uphold. Given you can do session/new to get the same effect, it
seems safer.
