### PR TITLE
fix: Remove hide Claude auth flag handling

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -330,10 +330,6 @@ function isMuslLibc(): boolean {
   return !report?.header?.glibcVersionRuntime;
 }
 
-function shouldHideClaudeAuth(): boolean {
-  return process.argv.includes("--hide-claude-auth");
-}
-
 // Bypass Permissions doesn't work if we are a root/sudo user
 const IS_ROOT = (process.geteuid?.() ?? process.getuid?.()) === 0;
 const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
@@ -564,7 +560,7 @@ export class ClaudeAcpAgent implements Agent {
         };
       }
 
-      if (!shouldHideClaudeAuth() && (supportsTerminalAuth || supportsMetaTerminalAuth)) {
+      if (supportsTerminalAuth || supportsMetaTerminalAuth) {
         terminalAuthMethods.push(remoteLoginMethod);
       }
     } else {
@@ -602,10 +598,8 @@ export class ClaudeAcpAgent implements Agent {
         };
       }
 
-      if (!shouldHideClaudeAuth() && (supportsTerminalAuth || supportsMetaTerminalAuth)) {
-        terminalAuthMethods.push(claudeLoginMethod);
-      }
       if (supportsTerminalAuth || supportsMetaTerminalAuth) {
+        terminalAuthMethods.push(claudeLoginMethod);
         terminalAuthMethods.push(consoleLoginMethod);
       }
     }
@@ -2143,17 +2137,6 @@ export class ClaudeAcpAgent implements Agent {
         throw RequestError.resourceNotFound(sessionId);
       }
       throw error;
-    }
-
-    if (
-      shouldHideClaudeAuth() &&
-      initializationResult.account.subscriptionType &&
-      !this.gatewayAuthRequest
-    ) {
-      throw RequestError.authRequired(
-        undefined,
-        "This integration does not support using claude.ai subscriptions.",
-      );
     }
 
     // Apply user's `availableModels` allowlist from settings.json before any

--- a/src/tests/authorization.test.ts
+++ b/src/tests/authorization.test.ts
@@ -163,63 +163,6 @@ describe("authorization", () => {
     );
   });
 
-  it("hide claude authentication without terminal-auth", async () => {
-    const [agent] = await createAgentMock();
-    vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
-
-    const initializeResponse = await agent.initialize({
-      protocolVersion: 1,
-      clientCapabilities: {
-        auth: { _meta: { gateway: true } },
-      } as any,
-    });
-    expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "claude-ai-login" }),
-    );
-    expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "console-login" }),
-    );
-    expect(initializeResponse.authMethods).toContainEqual(
-      expect.objectContaining({ id: "gateway" }),
-    );
-  });
-
-  it("hide claude auth but still show console login when terminal-auth is set", async () => {
-    const [agent] = await createAgentMock();
-    vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
-
-    const initializeResponse = await agent.initialize({
-      protocolVersion: 1,
-      clientCapabilities: {
-        _meta: { "terminal-auth": true },
-      },
-    });
-    expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "claude-ai-login" }),
-    );
-    expect(initializeResponse.authMethods).toContainEqual(
-      expect.objectContaining({ id: "console-login" }),
-    );
-  });
-
-  it("hide claude auth but still show console login with terminal capability", async () => {
-    const [agent] = await createAgentMock();
-    vi.stubGlobal("process", { ...process, argv: ["--hide-claude-auth"] });
-
-    const initializeResponse = await agent.initialize({
-      protocolVersion: 1,
-      clientCapabilities: {
-        auth: { terminal: true },
-      },
-    });
-    expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "claude-ai-login" }),
-    );
-    expect(initializeResponse.authMethods).toContainEqual(
-      expect.objectContaining({ id: "console-login" }),
-    );
-  });
-
   it("SSH session falls back to single legacy login method", async () => {
     const [agent] = await createAgentMock();
     vi.stubGlobal("process", { ...process, env: { ...process.env, SSH_TTY: "/dev/pts/0" } });
@@ -257,24 +200,6 @@ describe("authorization", () => {
     );
     expect(initializeResponse.authMethods).not.toContainEqual(
       expect.objectContaining({ id: "console-login" }),
-    );
-  });
-
-  it("remote environment respects hide-claude-auth", async () => {
-    const [agent] = await createAgentMock();
-    vi.stubGlobal("process", {
-      ...process,
-      argv: ["--hide-claude-auth"],
-      env: { ...process.env, SSH_CONNECTION: "192.168.1.1 12345 192.168.1.2 22" },
-    });
-
-    const initializeResponse = await agent.initialize({
-      protocolVersion: 1,
-      clientCapabilities: { auth: { terminal: true } },
-    });
-
-    expect(initializeResponse.authMethods).not.toContainEqual(
-      expect.objectContaining({ id: "claude-login" }),
     );
   });
 


### PR DESCRIPTION
Now that the terms are clear, we can let people use their credits if
they like in all scenarios.
