### PR TITLE
fix: forward task_started / task_notification between turns via a single-consumer session reader

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -191,6 +191,11 @@ type Session = {
   query: Query;
   input: Pushable<SDKUserMessage>;
   cancelled: boolean;
+  /** True after a client interrupt while a turn is active. Unlike
+   *  `cancelled`, this survives a queued follow-up prompt's entry reset so the
+   *  interrupted turn's late terminal error can still be treated as a benign
+   *  cancellation. Cleared when the interrupted turn ends. */
+  interrupted: boolean;
   cwd: string;
   /** Serialized snapshot of session-defining params (cwd, mcpServers) used to
    *  detect when loadSession/resumeSession is called with changed values. */
@@ -1296,6 +1301,17 @@ export class ClaudeAcpAgent implements Agent {
               break;
             }
 
+            // Interrupt & send: a queued follow-up prompt resets
+            // `session.cancelled` when it enters prompt(), but the interrupted
+            // turn can still later yield its terminal is_error result. Treat
+            // that result as the cancelled turn winding down instead of
+            // failing the session and cancelling the queued prompt.
+            if (session.interrupted && message.is_error && !isTaskNotification) {
+              session.interrupted = false;
+              stopReason = "cancelled";
+              break;
+            }
+
             switch (message.subtype) {
               case "success": {
                 if (message.result.includes("Please run /login")) {
@@ -1758,6 +1774,7 @@ export class ClaudeAcpAgent implements Agent {
       if (session.cancelController === cancelController) {
         session.cancelController = undefined;
       }
+      session.interrupted = false;
       if (!handedOff) {
         session.promptRunning = false;
         if (errored || session.cancelled) {
@@ -2149,6 +2166,9 @@ export class ClaudeAcpAgent implements Agent {
       return;
     }
     session.cancelled = true;
+    if (session.promptRunning || session.cancelController) {
+      session.interrupted = true;
+    }
     for (const [, pending] of session.pendingMessages) {
       pending.resolve(true);
     }
@@ -3209,6 +3229,7 @@ export class ClaudeAcpAgent implements Agent {
       query: q,
       input: input,
       cancelled: false,
+      interrupted: false,
       cwd: params.cwd,
       sessionFingerprint: computeSessionFingerprint(params),
       settingsManager,

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -55,9 +55,12 @@ import {
   PermissionUpdate,
   Query,
   query,
+  SDKMessage,
+  SDKResultMessage,
+  SDKTaskNotificationMessage,
+  SDKTaskStartedMessage,
   Settings,
   SDKAssistantMessageError,
-  SDKMessage,
   SDKMessageOrigin,
   SDKPartialAssistantMessage,
   SDKUserMessage,
@@ -97,6 +100,7 @@ import {
   toolUpdateFromToolResult,
 } from "./tools.js";
 import { nodeToWebReadable, nodeToWebWritable, Pushable, unreachable } from "./utils.js";
+import { classifyOffTurn, OffTurnFollowupCollector, TurnQueue } from "./session-reader.js";
 
 export const CLAUDE_CONFIG_DIR =
   process.env.CLAUDE_CONFIG_DIR ?? path.join(os.homedir(), ".claude");
@@ -156,6 +160,23 @@ const DEFAULT_CONTEXT_WINDOW = 200000;
  *  "obviously stuck" ceiling, not a guess at interrupt latency, so it can't
  *  pre-empt a slow-but-healthy interrupt. */
 const DEFAULT_FORCE_CANCEL_GRACE_MS = 30_000;
+
+/** How long teardown waits for the reader's detached side-effect chain
+ *  (`session.readerSideEffects`) to drain before deleting the session. A
+ *  wedged ACP client can't hang teardown past this. Side effects that have
+ *  not started by the time the session entry is deleted no-op via the
+ *  instance guard in `#enqueueReaderSideEffect`; an already-started client
+ *  request cannot be cancelled here. See #336. */
+const READER_SIDE_EFFECT_DRAIN_TIMEOUT_MS = 2000;
+
+/** How long teardown waits for the session reader (`session.readerDone`) to
+ *  exit before deleting the session. Normally the reader returns promptly once
+ *  the query is closed/aborted, but if the SDK iterator is genuinely wedged
+ *  (the same #680 scenario that wedges a prompt loop) the reader stays parked
+ *  in `query.next()` and never resolves. The orphaned reader exits safely on
+ *  its own (it re-checks `session !== initial` and the abort signal) if the
+ *  query ever yields, so teardown must not block on it indefinitely. */
+const READER_DONE_DRAIN_TIMEOUT_MS = 2000;
 
 /** Internal model-selection state. Mirrors the shape the ACP SDK exposed as
  *  `SessionModelState` before model selection moved entirely into
@@ -229,6 +250,25 @@ type Session = {
    *  NOT READ YET — recorded now so the mapping exists if/when we wire up
    *  fork/rewind. */
   messageIdToUuid: Map<string, string>;
+  /** Single-consumer queue fed by `#runSessionReader` while a prompt() turn
+   *  is active. prompt() drains it via `turnQueue.take()` instead of touching
+   *  the SDK iterator directly, so there is only ever one consumer of
+   *  `session.query.next()` (the reader). See issue #336. */
+  turnQueue: TurnQueue;
+  /** State machine for SDK messages the reader sees while no prompt() is
+   *  active. Lifecycle messages bypass it (emitted directly by the reader);
+   *  everything else accumulates as a followup-candidate until the closing
+   *  result/idle decides whether to forward or discard. */
+  offTurn: OffTurnFollowupCollector;
+  /** Resolves when `#runSessionReader` exits (abort, close, throw). Awaited
+   *  by `teardownSession` and the process-died recovery so the reader is
+   *  fully done before the session entry is deleted. */
+  readerDone: Promise<void>;
+  /** Ordered non-blocking side effects scheduled by the session reader
+   *  (raw SDK emits, lifecycle updates, autonomous followup forwarding).
+   *  The reader never awaits this chain, so a slow ACP client cannot stop
+   *  SDK consumption or block the next prompt from starting. */
+  readerSideEffects: Promise<void>;
 };
 
 /** Compute a stable fingerprint of the session-defining params so we can
@@ -899,11 +939,19 @@ export class ClaudeAcpAgent implements Agent {
       if (cancelled) {
         return { stopReason: "cancelled" };
       }
+      // We were queued behind a previous turn and have now been handed the
+      // stream. Re-assert promptRunning before consuming the turnQueue: in the
+      // normal handoff it is already true, but the finally-fallback below
+      // (the prior turn ended without replaying our message) resolves us
+      // *after* setting promptRunning=false. The reader keys off promptRunning
+      // to decide whether to route messages into the turnQueue we're about to
+      // read or off-turn — if it were left false our turn's messages would be
+      // misrouted to the off-turn collector and this prompt would hang. See #336.
+      session.promptRunning = true;
     } else {
       session.input.push(userMessage);
+      session.promptRunning = true;
     }
-
-    session.promptRunning = true;
     let handedOff = false;
     let errored = false;
     let stopReason: StopReason = "end_turn";
@@ -918,14 +966,21 @@ export class ClaudeAcpAgent implements Agent {
 
     try {
       while (true) {
-        const nextMessage = session.query.next();
-        const next = await Promise.race([nextMessage, cancelled]);
+        // Consume messages from the per-session reader, which is the sole
+        // consumer of session.query.next() (see #runSessionReader). The
+        // reader pushes only while promptRunning is true; off-turn messages
+        // are emitted as lifecycle or handled by the followup collector.
+        // See issue #336. The take() is raced against the force-cancel
+        // wake-up channel: when the SDK is wedged (e.g. a TaskOutput block,
+        // issue #680) the reader never pushes, so take() would hang forever —
+        // cancelController aborting lets the loop honor the cancel anyway.
+        const next = await Promise.race([session.turnQueue.take(), cancelled]);
         if (cancelController.signal.aborted) {
           // The SDK never yielded after interrupt() (e.g. a wedged TaskOutput
-          // block). Abandon the in-flight next() — swallowing any later
-          // rejection so it can't surface as an unhandled rejection — and
-          // honor the cancel per the ACP contract.
-          void nextMessage.catch(() => {});
+          // block) so the reader never pushed to the queue. Abandon the
+          // pending take() so the next prompt's take() doesn't trip the
+          // single-consumer guard, and honor the cancel per the ACP contract.
+          session.turnQueue.abandonTake();
           return { stopReason: "cancelled" };
         }
         const { value: message, done } = next as IteratorResult<SDKMessage, void>;
@@ -935,16 +990,6 @@ export class ClaudeAcpAgent implements Agent {
             return { stopReason: "cancelled" };
           }
           break;
-        }
-
-        if (
-          session.emitRawSDKMessages &&
-          shouldEmitRawMessage(session.emitRawSDKMessages, message)
-        ) {
-          await this.client.extNotification("_claude/sdkMessage", {
-            sessionId: params.sessionId,
-            message: message as Record<string, unknown>,
-          });
         }
 
         switch (message.type) {
@@ -1140,12 +1185,17 @@ export class ClaudeAcpAgent implements Agent {
                 });
                 break;
               }
+              case "task_started":
+              case "task_notification":
+                // Unreachable in practice: #runSessionReader intercepts
+                // task lifecycle for every turn state and emits it directly,
+                // so these never reach the turnQueue that prompt() consumes.
+                // Kept only for switch exhaustiveness. See #336.
+                break;
               case "hook_started":
               case "hook_progress":
               case "hook_response":
               case "files_persisted":
-              case "task_started":
-              case "task_notification":
               case "task_progress":
               case "task_updated":
                 break;
@@ -1634,51 +1684,66 @@ export class ClaudeAcpAgent implements Agent {
       throw new Error("Session did not end in result");
     } catch (error) {
       errored = true;
-      // A failed turn typically leaves a trailing `session_state_changed: idle`
-      // (and possibly more) in the query iterator. If we don't drain it here,
-      // the next prompt's first `query.next()` consumes that stale idle and
-      // short-circuits to end_turn with zero usage
-      // Bounded so a misbehaving SDK can't hang the next prompt indefinitely.
+      // A failed turn typically leaves trailing messages in the SDK iterator
+      // (a result with the error, a `session_state_changed: idle`). The
+      // session reader keeps consuming them and the off-turn collector
+      // discards anything that isn't a real task-notification followup, so
+      // we don't need to drain manually here. We do still need to interrupt
+      // the SDK so it stops producing.
       try {
         await session.query.interrupt();
-        const MAX_DRAIN = 100;
-        for (let i = 0; i < MAX_DRAIN; i++) {
-          const { value: m, done } = await session.query.next();
-          if (done || !m) break;
-          if (m.type === "system" && m.subtype === "session_state_changed" && m.state === "idle") {
-            break;
-          }
-          if (i === MAX_DRAIN - 1) {
-            this.logger.error(
-              `Session ${params.sessionId}: drained ${MAX_DRAIN} messages after error without observing idle`,
-            );
-          }
-        }
       } catch (drainErr) {
         this.logger.error(
-          `Session ${params.sessionId}: failed to drain query after prompt error:`,
+          `Session ${params.sessionId}: failed to interrupt query after prompt error:`,
           drainErr,
         );
+      }
+
+      // A force-cancel can win the race against an error: if cancel() aborted
+      // the wake-up channel (or teardown did), honor the cancel contract and
+      // return "cancelled" rather than surfacing the trailing error. Otherwise
+      // a cancel that coincides with an iterator throw would be misreported to
+      // the client as an internal error. See issues #680 and #336.
+      if (cancelController.signal.aborted || session.cancelled) {
+        return { stopReason: "cancelled" };
       }
 
       if (error instanceof RequestError || !(error instanceof Error)) {
         throw error;
       }
       const message = error.message;
-      if (
+      const processDied =
         message.includes("ProcessTransport") ||
         message.includes("terminated process") ||
         message.includes("process exited with") ||
         message.includes("process terminated by signal") ||
-        message.includes("Failed to write to process stdin")
-      ) {
-        this.logger.error(`Session ${params.sessionId}: Claude Agent process died: ${message}`);
+        message.includes("Failed to write to process stdin");
+      // The session reader is the sole consumer of the SDK iterator and is
+      // spawned exactly once. If its queue is in a terminal state the reader
+      // has exited (iterator threw or returned done) and will never feed this
+      // session again, so every future prompt() would fail the same way. Tear
+      // the session down so the client starts a fresh one instead of looping
+      // on a permanently bricked session. See #336.
+      const readerDead = session.turnQueue.isTerminal();
+      if (processDied || readerDead) {
+        this.logger.error(
+          processDied
+            ? `Session ${params.sessionId}: Claude Agent process died: ${message}`
+            : `Session ${params.sessionId}: session reader exited; tearing down session: ${message}`,
+        );
         session.settingsManager.dispose();
+        // Abort first so the reader exits its `query.next()` await cleanly,
+        // then wait for it to finish before deleting the entry. This avoids
+        // a leaked reader holding a reference to the disposed session.
+        session.abortController.abort();
         session.input.end();
+        await this.#drainReader(session);
         delete this.sessions[params.sessionId];
         throw RequestError.internalError(
           undefined,
-          "The Claude Agent process exited unexpectedly. Please start a new session.",
+          processDied
+            ? "The Claude Agent process exited unexpectedly. Please start a new session."
+            : "The Claude Agent session ended unexpectedly. Please start a new session.",
         );
       }
       throw error;
@@ -1695,11 +1760,20 @@ export class ClaudeAcpAgent implements Agent {
       }
       if (!handedOff) {
         session.promptRunning = false;
+        if (errored || session.cancelled) {
+          // The reader can run ahead of prompt() and queue messages for the
+          // active turn. If this prompt failed or was cancelled before
+          // consuming them, drop the leftovers so the next user prompt
+          // doesn't process stale/cancelled turn output. Done after
+          // promptRunning=false so the reader routes any further messages
+          // off-turn instead of back into the queue we just cleared.
+          session.turnQueue.clear();
+        }
         if (errored) {
-          // The query stream was just drained — handing pending prompts off
-          // onto it would let them race with the recovery. Cancel them so
-          // each waiting prompt() returns stopReason: "cancelled" and the
-          // client can decide whether to retry.
+          // The turn errored and we interrupted the query — handing pending
+          // prompts off onto the recovering stream would let them race with
+          // the recovery. Cancel them so each waiting prompt() returns
+          // stopReason: "cancelled" and the client can decide whether to retry.
           for (const pending of session.pendingMessages.values()) {
             pending.resolve(true);
           }
@@ -1718,6 +1792,355 @@ export class ClaudeAcpAgent implements Agent {
         }
       }
     }
+  }
+
+  /** Forward an SDK task lifecycle event (`task_started` /
+   *  `task_notification`) to the ACP client as a notification chunk. Called
+   *  both from inside prompt()'s loop (when a turn is active) and from
+   *  `#runSessionReader` (when no turn is running) so the client receives
+   *  these updates regardless of whether the user is mid-conversation. See
+   *  issue #336.
+   *
+   *  The current shape is intentionally minimal — text-mode `agent_message_chunk`
+   *  matches the sketch in the issue body and reaches every existing ACP
+   *  client. A future change could expose a dedicated `task_*` session-update
+   *  variant if the protocol gains one. */
+  async #emitTaskLifecycleUpdate(
+    sessionId: string,
+    message: SDKTaskStartedMessage | SDKTaskNotificationMessage,
+  ): Promise<void> {
+    if (message.skip_transcript) return;
+    const lines: string[] = [];
+    if (message.subtype === "task_started") {
+      const label = message.description ? `: ${message.description}` : "";
+      lines.push(`[task ${message.task_id}] started${label}`);
+    } else {
+      const label = message.summary ? `: ${message.summary}` : "";
+      lines.push(`[task ${message.task_id}] ${message.status}${label}`);
+      if (message.output_file) {
+        lines.push(`output: ${message.output_file}`);
+      }
+    }
+    try {
+      // Route to the reader's bound sessionId (the ACP session key), not
+      // message.session_id, which for subagent/task events can be a
+      // task-scoped id the client doesn't map. #emitFollowup does the same.
+      //
+      // Wrap the text in blank lines on both sides. Clients concatenate
+      // consecutive agent_message_chunks raw (chunk.text + chunk.text), so
+      // without a separator several lifecycle chunks that land back-to-back
+      // (e.g. two background tasks finishing together) and the agent text that
+      // follows fuse into one run. A single "\n" is not enough for markdown
+      // clients: with no hard-break extension a lone newline renders as a
+      // space, so only a blank line ("\n\n", a paragraph break) actually
+      // separates the lines visually. Both sides are needed — the leading pair
+      // detaches from preceding text, the trailing pair from following text.
+      await this.client.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: `\n\n${lines.join("\n")}\n\n` },
+        },
+      });
+    } catch (err) {
+      this.logger.error(`Session ${sessionId}: failed to forward task lifecycle update:`, err);
+    }
+  }
+
+  /** Forward an autonomous task-notification followup (assistant chunks +
+   *  result) to the client out-of-turn. Called by the off-turn collector
+   *  when a `result` with `origin.kind === 'task-notification'` closes a
+   *  buffered group. We render the followup using the same notification
+   *  helpers prompt() uses for in-turn messages, so the client sees a
+   *  consistent stream, but we never touch session.accumulatedUsage,
+   *  stopReason, or pending prompts — this is independent of any user turn.
+   *  See issue #336. */
+  async #emitFollowup(
+    sessionId: string,
+    buffered: SDKMessage[],
+    result: SDKResultMessage,
+  ): Promise<void> {
+    const session = this.sessions[sessionId];
+    if (!session) return;
+    const isCurrentSession = (): boolean => this.sessions[sessionId] === session;
+
+    // A followup is a self-contained group; its tool_use/tool_result pairs are
+    // internal to the group. Use a local cache (like replaySessionHistory)
+    // rather than session.toolUseCache: the followup runs detached on the
+    // reader's side-effect chain and can overlap a live prompt() turn that is
+    // concurrently mutating session.toolUseCache, so sharing it would corrupt
+    // the live turn's tool-call rendering. See issue #336.
+    const toolUseCache: ToolUseCache = {};
+
+    // Track which top-level message ids actually streamed text/thinking via
+    // stream_event deltas, so the assembled `assistant` block is dropped as a
+    // duplicate when it streamed and forwarded as a fallback when it did not.
+    // Mirrors the in-turn handler in prompt() so a followup behind a
+    // non-streaming gateway (e.g. an OpenAI-compatible proxy that returns the
+    // turn as one un-streamed block) still delivers its final answer. See #757.
+    // The delta events don't carry the API message id, so it is captured from
+    // the preceding `message_start` (the same id messageIdForGrouping returns
+    // for the consolidated assistant message), keyed identically so they match.
+    let currentStreamMessageId: string | undefined;
+    const streamedTextIds = new Set<string>();
+    const streamedThinkingIds = new Set<string>();
+
+    for (const message of buffered) {
+      if (!isCurrentSession()) return;
+      try {
+        if (message.type === "stream_event") {
+          if (message.event.type === "message_start") {
+            currentStreamMessageId = message.event.message.id || undefined;
+          }
+          if (
+            currentStreamMessageId &&
+            message.parent_tool_use_id === null &&
+            message.event.type === "content_block_delta"
+          ) {
+            if (message.event.delta.type === "text_delta") {
+              streamedTextIds.add(currentStreamMessageId);
+            } else if (message.event.delta.type === "thinking_delta") {
+              streamedThinkingIds.add(currentStreamMessageId);
+            }
+          }
+          for (const notification of streamEventToAcpNotifications(
+            message as SDKPartialAssistantMessage,
+            sessionId,
+            toolUseCache,
+            this.client,
+            this.logger,
+            {
+              clientCapabilities: this.clientCapabilities,
+              cwd: session.cwd,
+              taskState: session.taskState,
+            },
+          )) {
+            if (!isCurrentSession()) return;
+            await this.client.sessionUpdate(notification);
+          }
+          continue;
+        }
+        if (message.type === "user" || message.type === "assistant") {
+          // The SDK widened message.message.role to include "system"; those
+          // carry no client-renderable content here, and toAcpNotifications
+          // only accepts "user" | "assistant". Skip them, mirroring the
+          // in-turn handler in prompt().
+          if (message.message.role === "system") continue;
+          let content: typeof message.message.content;
+          if (message.type === "assistant" && message.parent_tool_use_id === null) {
+            // Top-level assistant message: drop text/thinking blocks already
+            // streamed live as chunks, forward (as a fallback) any that were
+            // not, so non-streaming gateways still deliver the followup's
+            // answer. Mirrors prompt()'s in-turn filter. See #757.
+            const id = messageIdForGrouping(message);
+            content = message.message.content.filter((item) => {
+              if (item.type !== "text" && item.type !== "thinking") {
+                return true;
+              }
+              const streamedLive =
+                id !== undefined &&
+                (item.type === "text" ? streamedTextIds : streamedThinkingIds).has(id);
+              if (streamedLive) {
+                return false;
+              }
+              const text = item.type === "text" ? item.text : item.thinking;
+              return text.length > 0;
+            });
+          } else if (message.type === "assistant") {
+            // Subagent assistant message: never streamed live and internal to
+            // the tool call, so keep dropping its text/thinking.
+            content = message.message.content.filter(
+              (item) => item.type !== "text" && item.type !== "thinking",
+            );
+          } else {
+            content = message.message.content;
+          }
+          for (const notification of toAcpNotifications(
+            content,
+            message.message.role,
+            sessionId,
+            toolUseCache,
+            this.client,
+            this.logger,
+            {
+              clientCapabilities: this.clientCapabilities,
+              parentToolUseId: message.parent_tool_use_id,
+              cwd: session.cwd,
+              taskState: session.taskState,
+            },
+          )) {
+            if (!isCurrentSession()) return;
+            await this.client.sessionUpdate(notification);
+          }
+        }
+      } catch (err) {
+        this.logger.error(`Session ${sessionId}: failed to forward followup message:`, err);
+      }
+    }
+
+    const followupUsage = computeFollowupUsageUpdate(buffered, result, session.contextWindowSize);
+    try {
+      if (!isCurrentSession()) return;
+      await this.client.sessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: "usage_update",
+          used: followupUsage.used,
+          size: followupUsage.size,
+          cost: {
+            amount: result.total_cost_usd,
+            currency: "USD",
+          },
+          ...(result.origin && {
+            _meta: { "_claude/origin": result.origin },
+          }),
+        },
+      });
+    } catch (err) {
+      this.logger.error(`Session ${sessionId}: failed to emit followup usage_update:`, err);
+    }
+  }
+
+  #enqueueReaderSideEffect(sessionId: string, effect: () => Promise<void>): void {
+    const session = this.sessions[sessionId];
+    if (!session) return;
+    session.readerSideEffects = session.readerSideEffects
+      .then(async () => {
+        if (this.sessions[sessionId] !== session) return;
+        await effect();
+      })
+      .catch((err) => {
+        this.logger.error(`Session ${sessionId}: session reader side effect failed:`, err);
+      });
+  }
+
+  /** Per-session reader. Sole consumer of `session.query.next()`. Lifecycle
+   *  messages are forwarded to the client immediately. In-turn messages
+   *  (while prompt() is running) are pushed onto the session's `turnQueue`.
+   *  Off-turn messages are fed to the `offTurn` collector, which decides
+   *  whether to forward them as an autonomous followup or discard them.
+   *  Exits on abort, iterator close, or iterator throw; in all cases the
+   *  `turnQueue` is closed/errored so any consumer is unblocked, and the
+   *  caller's `resolveDone()` is invoked. See issue #336. */
+  async #runSessionReader(sessionId: string, resolveDone: () => void): Promise<void> {
+    const initial = this.sessions[sessionId];
+    if (!initial) {
+      resolveDone();
+      return;
+    }
+    try {
+      while (true) {
+        const session = this.sessions[sessionId];
+        // Session was deleted or replaced under us — stop reading from a
+        // stale iterator. The finally below closes turnQueue / resets
+        // offTurn so no consumer is left hanging.
+        if (!session || session !== initial) return;
+        if (initial.abortController.signal.aborted) return;
+
+        let res: IteratorResult<SDKMessage, void>;
+        try {
+          res = await session.query.next();
+        } catch (err) {
+          // Iterator threw — propagate to the active consumer (if any) so
+          // prompt() surfaces the error to the caller, and exit. The
+          // process-died recovery in prompt() handles map cleanup.
+          if (initial.abortController.signal.aborted) {
+            // Abort during teardown is expected; don't noise the log.
+            session.turnQueue.close();
+          } else {
+            this.logger.error(`Session ${sessionId}: session reader stopped:`, err);
+            session.turnQueue.error(err);
+          }
+          session.offTurn.reset();
+          return;
+        }
+        if (res.done) {
+          session.turnQueue.close();
+          session.offTurn.reset();
+          return;
+        }
+        const message = res.value;
+        if (!message) continue;
+
+        // Raw SDK emit is unified here so clients with emitRawSDKMessages
+        // see every message regardless of whether a turn is active.
+        //
+        // Ordering contract: raw `_claude/sdkMessage` notifications are a
+        // standalone telemetry channel. They are FIFO-ordered among
+        // themselves (the readerSideEffects chain is a strict promise
+        // sequence), but they are NOT ordered relative to the derived
+        // session/update stream that prompt() emits inline — the reader
+        // does not block on the client, so a message's parsed update can
+        // reach the client before its raw form. Clients must not assume
+        // raw precedes the derived update for a given message.
+        if (
+          session.emitRawSDKMessages &&
+          shouldEmitRawMessage(session.emitRawSDKMessages, message)
+        ) {
+          this.#enqueueReaderSideEffect(sessionId, async () => {
+            try {
+              await this.client.extNotification("_claude/sdkMessage", {
+                sessionId,
+                message: message as Record<string, unknown>,
+              });
+            } catch (err) {
+              this.logger.error(`Session ${sessionId}: raw SDK emit failed:`, err);
+            }
+          });
+        }
+
+        // Lifecycle is forwarded immediately, regardless of turn state.
+        // classifyOffTurn is the single source of truth for which subtypes are
+        // lifecycle vs followup-candidate (see session-reader.ts); the narrowed
+        // type lets #emitTaskLifecycleUpdate accept it directly.
+        if (classifyOffTurn(message) === "lifecycle") {
+          this.#enqueueReaderSideEffect(sessionId, () =>
+            this.#emitTaskLifecycleUpdate(
+              sessionId,
+              message as SDKTaskStartedMessage | SDKTaskNotificationMessage,
+            ),
+          );
+          continue;
+        }
+
+        // In-turn: hand off to prompt() via the queue. The reader checks
+        // promptRunning *after* obtaining the message, so a turn that just
+        // started gets the message; a turn that just ended sees nothing
+        // (the off-turn collector handles those instead).
+        if (session.promptRunning) {
+          session.turnQueue.push(message);
+          continue;
+        }
+
+        // Off-turn: feed the followup state machine.
+        await session.offTurn.accept(message);
+      }
+    } finally {
+      // Final cleanup: every exit path lands here. close() and reset() are
+      // idempotent, so the inner branches that already called them stay
+      // correct, and any future early-return we add gets safe defaults.
+      initial.turnQueue.close();
+      initial.offTurn.reset();
+      resolveDone();
+    }
+  }
+
+  /** Test-only hook so unit tests can drive the session reader without
+   *  going through `newSession`'s heavyweight init (SDK CLI spawn, settings
+   *  load). Not part of the public API. */
+  startSessionReaderForTest(sessionId: string, resolveDone?: () => void): Promise<void> {
+    return this.#runSessionReader(sessionId, resolveDone ?? (() => {}));
+  }
+
+  /** Test-only hook so unit tests can exercise the real followup-forwarding
+   *  path (#emitFollowup) end-to-end without reaching into a private field.
+   *  Not part of the public API. */
+  emitFollowupForTest(
+    sessionId: string,
+    buffered: SDKMessage[],
+    result: SDKResultMessage,
+  ): Promise<void> {
+    return this.#emitFollowup(sessionId, buffered, result);
   }
 
   async cancel(params: CancelNotification): Promise<void> {
@@ -1760,6 +2183,19 @@ export class ClaudeAcpAgent implements Agent {
     await session.query.interrupt();
   }
 
+  /** Wait (bounded) for a session's reader to exit, then drain its detached
+   *  side-effect chain. A wedged SDK iterator (issue #680) can leave the reader
+   *  parked in query.next() forever, so neither wait can be unbounded — the
+   *  orphaned reader exits on its own once the query yields (it re-checks
+   *  `session !== initial`). Draining readerSideEffects after readerDone lets
+   *  queued lifecycle/raw/followup emits finish before the session entry is
+   *  deleted, so a late sessionUpdate can't land for a closed session. See
+   *  issue #336. */
+  async #drainReader(session: Session): Promise<void> {
+    await settleWithin(session.readerDone, READER_DONE_DRAIN_TIMEOUT_MS);
+    await settleWithin(session.readerSideEffects, READER_SIDE_EFFECT_DRAIN_TIMEOUT_MS);
+  }
+
   /** Cleanly tear down a session: cancel in-flight work, dispose resources,
    *  and remove it from the session map. */
   private async teardownSession(sessionId: string): Promise<void> {
@@ -1783,6 +2219,10 @@ export class ClaudeAcpAgent implements Agent {
     session.settingsManager.dispose();
     session.abortController.abort();
     session.query.close();
+    // Wait for the session reader to exit and its side effects to drain before
+    // deleting the entry, so an in-flight read completes deterministically and
+    // no late sessionUpdate lands for a closed session.
+    await this.#drainReader(session);
     delete this.sessions[sessionId];
   }
 
@@ -2792,7 +3232,29 @@ export class ClaudeAcpAgent implements Agent {
       taskState,
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector(
+        sessionId,
+        async (msgs, result) => {
+          this.#enqueueReaderSideEffect(sessionId, () =>
+            this.#emitFollowup(sessionId, msgs, result),
+          );
+        },
+        this.logger,
+      ),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    // Spawn the session reader so task_started / task_notification events
+    // delivered between turns reach the ACP client (#336).
+    let resolveReaderDone!: () => void;
+    this.sessions[sessionId].readerDone = new Promise<void>((resolve) => {
+      resolveReaderDone = resolve;
+    });
+    void this.#runSessionReader(sessionId, resolveReaderDone).catch((err) => {
+      this.logger.error(`Session ${sessionId}: session reader crashed:`, err);
+      resolveReaderDone();
+    });
 
     return {
       sessionId,
@@ -2841,6 +3303,93 @@ function totalTokens(usage: UsageSnapshot): number {
     usage.cache_read_input_tokens +
     usage.cache_creation_input_tokens
   );
+}
+
+/** Await `p` but give up after `ms`. Always resolves (never rejects), so it
+ *  is safe to use in teardown paths where we want best-effort draining
+ *  without risking a hang on a wedged downstream. */
+async function settleWithin(p: Promise<unknown>, ms: number): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, ms);
+  });
+  try {
+    await Promise.race([
+      p.then(
+        () => {},
+        () => {},
+      ),
+      timeout,
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/** Derive the `used`/`size` for an autonomous followup's usage_update from
+ *  its buffered messages, mirroring prompt()'s in-turn usage tracking.
+ *
+ *  Deliberate scope/semantics (so the followup never corrupts user-turn state):
+ *  - Only top-level (`parent_tool_use_id === null`) messages update the usage
+ *    snapshot, matching the in-turn logic — subagent token spend doesn't count
+ *    toward the main thread's context occupancy.
+ *  - If the followup is entirely subagent work (no top-level message), there is
+ *    no main-thread snapshot, so we fall back to `result.usage` as a coarse
+ *    proxy. It may overstate main-thread occupancy, but it's the only
+ *    aggregate available and it's strictly informational for a background task.
+ *  - We never write the learned context window back to the session: a followup
+ *    runs out-of-turn and must not mutate `session.contextWindowSize`, which
+ *    belongs to the user's turns. `fallbackContextWindow` is read-only here. */
+export function computeFollowupUsageUpdate(
+  buffered: SDKMessage[],
+  result: SDKResultMessage,
+  fallbackContextWindow: number,
+): { used: number; size: number } {
+  let lastUsage: UsageSnapshot | null = null;
+  let lastModel: string | null = null;
+
+  for (const message of buffered) {
+    if (message.type === "stream_event" && message.parent_tool_use_id === null) {
+      if (message.event.type === "message_start") {
+        lastUsage = snapshotFromUsage(message.event.message.usage);
+        const model = message.event.message.model;
+        if (model && model !== "<synthetic>") {
+          lastModel = model;
+        }
+      } else if (message.event.type === "message_delta") {
+        const usage = message.event.usage;
+        const prev: Readonly<UsageSnapshot> = lastUsage ?? ZERO_USAGE;
+        // Per Anthropic API, message_delta usage is cumulative; the nullable
+        // fields fall back to the prior snapshot when omitted. output_tokens
+        // is guaranteed non-null, so it is not coalesced — same treatment as
+        // the in-turn handler.
+        lastUsage = {
+          input_tokens: usage.input_tokens ?? prev.input_tokens,
+          output_tokens: usage.output_tokens,
+          cache_read_input_tokens: usage.cache_read_input_tokens ?? prev.cache_read_input_tokens,
+          cache_creation_input_tokens:
+            usage.cache_creation_input_tokens ?? prev.cache_creation_input_tokens,
+        };
+      }
+      continue;
+    }
+
+    if (message.type === "assistant" && message.parent_tool_use_id === null) {
+      lastUsage = snapshotFromUsage(message.message.usage);
+      const model = message.message.model;
+      if (model && model !== "<synthetic>") {
+        lastModel = model;
+      }
+    }
+  }
+
+  const matchingModelUsage = lastModel ? getMatchingModelUsage(result.modelUsage, lastModel) : null;
+  const inferredContextWindow = lastModel ? inferContextWindowFromModel(lastModel) : null;
+
+  return {
+    used: totalTokens(lastUsage ?? snapshotFromUsage(result.usage)),
+    size: matchingModelUsage?.contextWindow ?? inferredContextWindow ?? fallbackContextWindow,
+  };
 }
 
 /**

--- a/src/session-reader.ts
+++ b/src/session-reader.ts
@@ -63,6 +63,17 @@ export class TurnQueue {
     this.buffer = [];
   }
 
+  /** Drop a pending take() without resolving or rejecting it. Used when the
+   *  consumer force-cancels a turn (issue #680) while the producer (the
+   *  session reader) is wedged in `query.next()` and will never push: the
+   *  promise returned by the abandoned take() is left dangling on purpose
+   *  (nobody awaits it after the cancel), and clearing the waiter lets the
+   *  next turn's take() proceed without tripping the single-consumer guard. */
+  abandonTake(): void {
+    this.waiter = null;
+    this.waiterReject = null;
+  }
+
   /** Push an error to the consumer. A pending consumer is rejected. */
   error(err: unknown): void {
     if (this.closed || this.hasError) return;
@@ -101,6 +112,16 @@ export class TurnQueue {
   /** Test/diagnostic: number of buffered messages awaiting take(). */
   size(): number {
     return this.buffer.length;
+  }
+
+  /** True once the queue has been closed or errored. Terminal state is
+   *  permanent (there is no reset): the session reader is the sole producer
+   *  and is spawned once, so a closed/errored queue means the reader has
+   *  exited and will never feed this queue again. prompt() uses this to
+   *  recognize a dead session and tear it down instead of failing every
+   *  future take() on the latched state. */
+  isTerminal(): boolean {
+    return this.closed || this.hasError;
   }
 }
 

--- a/src/session-reader.ts
+++ b/src/session-reader.ts
@@ -1,0 +1,211 @@
+// Utilities that back the single-consumer session reader introduced for
+// issue #336. Three building blocks live here so they can be unit-tested in
+// isolation from acp-agent.ts:
+//
+//   - TurnQueue: single-producer / single-consumer async queue used by the
+//     reader to hand in-turn SDK messages to the active prompt() loop.
+//   - classifyOffTurn: pure classification of an off-turn message into either
+//     a task-lifecycle event (emit immediately) or a followup candidate
+//     (feed to the collector).
+//   - OffTurnFollowupCollector: tiny state machine that accumulates followup
+//     candidates between turns and decides at the closing result whether to
+//     forward them as an autonomous followup or discard them as aftermath.
+import type { SDKMessage, SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
+import type { Logger } from "./acp-agent.js";
+
+/** Single-producer / single-consumer async queue. The session reader is the
+ *  sole producer; prompt() is the sole consumer per turn. Errors raised on
+ *  the producer side (e.g. the SDK iterator throwing) propagate to whichever
+ *  side reads next so the consumer can surface them as a request error. */
+export class TurnQueue {
+  private buffer: SDKMessage[] = [];
+  private waiter: ((r: IteratorResult<SDKMessage>) => void) | null = null;
+  private waiterReject: ((err: unknown) => void) | null = null;
+  private err: unknown = undefined;
+  private hasError = false;
+  private closed = false;
+
+  /** Push a message. If a consumer is waiting, resolve it directly. */
+  push(msg: SDKMessage): void {
+    if (this.closed || this.hasError) {
+      // Drop silently: queue is in a terminal state. This branch only fires
+      // if the reader keeps producing after close/error, which would be a
+      // bug — we choose to drop rather than throw because the reader's
+      // top-level catch already logs.
+      return;
+    }
+    if (this.waiter) {
+      const w = this.waiter;
+      this.waiter = null;
+      this.waiterReject = null;
+      w({ value: msg, done: false });
+      return;
+    }
+    this.buffer.push(msg);
+  }
+
+  /** Mark the queue closed. A pending consumer is resolved with done:true.
+   *  Subsequent take() calls return done:true. Idempotent. */
+  close(): void {
+    if (this.closed || this.hasError) return;
+    this.closed = true;
+    if (this.waiter) {
+      const w = this.waiter;
+      this.waiter = null;
+      this.waiterReject = null;
+      w({ value: undefined as unknown as SDKMessage, done: true });
+    }
+  }
+
+  /** Drop buffered messages that were read for a turn the consumer has
+   *  abandoned. Does not resolve/reject a pending take(). */
+  clear(): void {
+    this.buffer = [];
+  }
+
+  /** Push an error to the consumer. A pending consumer is rejected. */
+  error(err: unknown): void {
+    if (this.closed || this.hasError) return;
+    this.hasError = true;
+    this.err = err;
+    if (this.waiterReject) {
+      const r = this.waiterReject;
+      this.waiter = null;
+      this.waiterReject = null;
+      r(err);
+    }
+  }
+
+  /** Consume the next message. Single-consumer: throws if a previous take()
+   *  is still pending. */
+  take(): Promise<IteratorResult<SDKMessage>> {
+    if (this.waiter) {
+      throw new Error("TurnQueue: concurrent take() is not supported");
+    }
+    if (this.buffer.length > 0) {
+      const value = this.buffer.shift()!;
+      return Promise.resolve({ value, done: false });
+    }
+    if (this.hasError) {
+      return Promise.reject(this.err);
+    }
+    if (this.closed) {
+      return Promise.resolve({ value: undefined as unknown as SDKMessage, done: true });
+    }
+    return new Promise<IteratorResult<SDKMessage>>((resolve, reject) => {
+      this.waiter = resolve;
+      this.waiterReject = reject;
+    });
+  }
+
+  /** Test/diagnostic: number of buffered messages awaiting take(). */
+  size(): number {
+    return this.buffer.length;
+  }
+}
+
+/** Classify a message the reader sees while no prompt() is active. Pure
+ *  function for testability and to keep the off-turn policy in one place. */
+export type OffTurnClassification = "lifecycle" | "followup-candidate";
+
+export function classifyOffTurn(msg: SDKMessage): OffTurnClassification {
+  if (
+    msg.type === "system" &&
+    (msg.subtype === "task_started" || msg.subtype === "task_notification")
+  ) {
+    return "lifecycle";
+  }
+  return "followup-candidate";
+}
+
+/** Soft cap on the followup-candidate buffer. The collector only buffers
+ *  off-turn messages until the SDK emits the closing `result` or `idle` of
+ *  the followup, so in normal operation the buffer stays small. The cap
+ *  exists to keep a misbehaving SDK (followup that never closes) from
+ *  growing memory without bound. Reaching it is logged as an error so we
+ *  notice. */
+const OFF_TURN_BUFFER_CAP = 256;
+
+export type FollowupEmitter = (msgs: SDKMessage[], result: SDKResultMessage) => Promise<void>;
+
+/** Mini state machine for messages that arrive while no prompt() is active.
+ *
+ *  States:
+ *    idle       — no buffered candidates
+ *    collecting — at least one candidate buffered; waiting for the closing
+ *                 result or session_state_changed:idle
+ *
+ *  Transitions:
+ *    any → result(origin=task-notification): emit followup, reset
+ *    any → result(other origin or none):     discard with log, reset
+ *    any → session_state_changed:idle:       discard with log if buffered, reset
+ *    any → otherwise:                        accumulate, state=collecting
+ *
+ *  Lifecycle messages (task_started / task_notification) never reach the
+ *  collector — the reader emits them directly. */
+export class OffTurnFollowupCollector {
+  private state: "idle" | "collecting" = "idle";
+  private buffer: SDKMessage[] = [];
+
+  constructor(
+    private readonly sessionId: string,
+    private readonly emitFollowup: FollowupEmitter,
+    private readonly logger: Logger,
+  ) {}
+
+  /** Process one off-turn message. Lifecycle messages must be filtered by
+   *  the caller before reaching this method. */
+  async accept(msg: SDKMessage): Promise<void> {
+    if (msg.type === "result") {
+      const origin = (msg as SDKResultMessage).origin;
+      const isFollowup = origin?.kind === "task-notification";
+      const buffered = this.buffer;
+      this.reset();
+      if (isFollowup) {
+        try {
+          await this.emitFollowup(buffered, msg as SDKResultMessage);
+        } catch (err) {
+          this.logger.error(`Session ${this.sessionId}: emitFollowup failed:`, err);
+        }
+      } else {
+        if (buffered.length > 0) {
+          this.logger.log(
+            `Session ${this.sessionId}: discarding ${buffered.length} off-turn messages followed by non-followup result`,
+          );
+        }
+      }
+      return;
+    }
+
+    if (msg.type === "system" && msg.subtype === "session_state_changed" && msg.state === "idle") {
+      if (this.buffer.length > 0) {
+        this.logger.log(
+          `Session ${this.sessionId}: discarding ${this.buffer.length} off-turn messages with no closing result`,
+        );
+      }
+      this.reset();
+      return;
+    }
+
+    if (this.buffer.length >= OFF_TURN_BUFFER_CAP) {
+      const dropped = this.buffer.shift();
+      this.logger.error(
+        `Session ${this.sessionId}: off-turn followup buffer cap reached (${OFF_TURN_BUFFER_CAP}); dropping oldest ${dropped?.type}`,
+      );
+    }
+    this.state = "collecting";
+    this.buffer.push(msg);
+  }
+
+  /** Discard any buffered followup-candidate messages. Used on teardown and
+   *  when the reader exits. */
+  reset(): void {
+    this.buffer = [];
+    this.state = "idle";
+  }
+
+  /** Diagnostic: current state for tests. */
+  inspect(): { state: "idle" | "collecting"; bufferSize: number } {
+    return { state: this.state, bufferSize: this.buffer.length };
+  }
+}

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -47,6 +47,11 @@ describe("ClaudeAcpAgent settings", () => {
         }),
         setModel: setModelSpy,
         supportedCommands: async () => [],
+        // Iterator stub for the session reader: returns a pending promise so
+        // the reader parks until the session is torn down. Tests that don't
+        // exercise prompt() never observe a message.
+        next: () => new Promise(() => {}),
+        close: () => {},
       } as any;
     });
     return { getCapturedOptions: () => capturedOptions, setModelSpy };
@@ -246,6 +251,11 @@ describe("ClaudeAcpAgent settings", () => {
           setModel: setModelSpy,
           setPermissionMode: setPermissionModeSpy,
           supportedCommands: async () => [],
+          // Iterator stub for the session reader: returns a pending promise so
+          // the reader parks until the session is torn down. Tests that don't
+          // exercise prompt() never observe a message.
+          next: () => new Promise(() => {}),
+          close: () => {},
         } as any;
       });
       return {
@@ -401,6 +411,11 @@ describe("ClaudeAcpAgent settings", () => {
           initializationResult: async () => ({ models }),
           setModel: setModelSpy,
           supportedCommands: async () => [],
+          // Iterator stub for the session reader: returns a pending promise so
+          // the reader parks until the session is torn down. Tests that don't
+          // exercise prompt() never observe a message.
+          next: () => new Promise(() => {}),
+          close: () => {},
         } as any;
       });
       return { setModelSpy };
@@ -732,6 +747,11 @@ describe("ClaudeAcpAgent settings", () => {
         }),
         setModel: setModelSpy,
         supportedCommands: async () => [],
+        // Iterator stub for the session reader: returns a pending promise so
+        // the reader parks until the session is torn down. Tests that don't
+        // exercise prompt() never observe a message.
+        next: () => new Promise(() => {}),
+        close: () => {},
       } as any;
     });
 
@@ -773,6 +793,11 @@ describe("ClaudeAcpAgent settings", () => {
         }),
         setModel: setModelSpy,
         supportedCommands: async () => [],
+        // Iterator stub for the session reader: returns a pending promise so
+        // the reader parks until the session is torn down. Tests that don't
+        // exercise prompt() never observe a message.
+        next: () => new Promise(() => {}),
+        close: () => {},
       } as any;
     });
 
@@ -826,6 +851,11 @@ describe("ClaudeAcpAgent settings", () => {
         }),
         setModel: setModelSpy,
         supportedCommands: async () => [],
+        // Iterator stub for the session reader: returns a pending promise so
+        // the reader parks until the session is torn down. Tests that don't
+        // exercise prompt() never observe a message.
+        next: () => new Promise(() => {}),
+        close: () => {},
       } as any;
     });
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1701,6 +1701,7 @@ describe("stop reason propagation", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: {
@@ -1857,6 +1858,7 @@ describe("stop reason propagation", () => {
       cwd: "/tmp/test",
       sessionFingerprint: JSON.stringify({ cwd: "/tmp/test", mcpServers: [] }),
       cancelled: false,
+      interrupted: false,
       modes: {
         currentModeId: "default",
         availableModes: [],
@@ -2024,6 +2026,7 @@ describe("session/close", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: {
@@ -2124,6 +2127,7 @@ describe("session/delete", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -2232,6 +2236,7 @@ describe("getOrCreateSession param change detection", () => {
       query: gen as any,
       input: new Pushable(),
       cancelled: false,
+      interrupted: false,
       cwd,
       sessionFingerprint: JSON.stringify({
         cwd,
@@ -2605,6 +2610,7 @@ describe("usage_update computation", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: {
@@ -3628,6 +3634,7 @@ describe("assembled assistant text fallback", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -3832,6 +3839,7 @@ describe("emitRawSDKMessages", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -4070,6 +4078,7 @@ describe("result origin handling", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -4255,6 +4264,7 @@ describe("memory_recall handling", () => {
       query: messageGenerator() as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -4495,6 +4505,7 @@ describe("post-error recovery", () => {
       query: gen as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -4650,6 +4661,7 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       query: gen as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       modes: { currentModeId: "default", availableModes: [] },
@@ -5121,6 +5133,7 @@ describe("session reader (issue #336)", () => {
       query: query as any,
       input,
       cancelled: false,
+      interrupted: false,
       cwd: "/test",
       sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
       settingsManager: { dispose: vi.fn() } as any,
@@ -6324,6 +6337,107 @@ describe("session reader (issue #336)", () => {
     for (const u of usageUpdates) {
       expect(u.update.used).not.toBe(9999 * 2);
     }
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("treats an interrupted turn's late is_error result as cancelled after a queued prompt resets cancelled", async () => {
+    // Interrupt & send races like this:
+    // 1. prompt A is running
+    // 2. cancel() marks the session cancelled
+    // 3. prompt B enters while A is still winding down and resets `cancelled`
+    // 4. A's terminal is_error result finally arrives
+    //
+    // Without the separate `interrupted` flag, step 4 throws an Internal error
+    // and cancels B out of pendingMessages.
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    const result = (overrides: Partial<Record<string, unknown>> = {}) => ({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u-result",
+      session_id: "s1",
+      ...overrides,
+    });
+    const idle = (uuid: string) => ({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid,
+      session_id: "s1",
+    });
+
+    const promptA = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await vi.waitFor(() => expect(session.promptRunning).toBe(true));
+    query.push({
+      type: "user",
+      message: { role: "user", content: "first" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u-a",
+      session_id: "s1",
+    });
+
+    await agent.cancel({ sessionId: "s1" });
+    expect(session.cancelled).toBe(true);
+    expect(session.interrupted).toBe(true);
+
+    const promptB = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    await vi.waitFor(() => expect(session.pendingMessages.size).toBe(1));
+    expect(session.cancelled).toBe(false);
+    expect(session.interrupted).toBe(true);
+
+    query.push(
+      result({
+        is_error: true,
+        result: "[ede_diagnostic] result_type=user stop_reason=tool_use",
+        stop_reason: "tool_use",
+        uuid: "u-a-error",
+      }),
+    );
+    await vi.waitFor(() => expect(session.interrupted).toBe(false));
+
+    const [queuedUuid] = session.pendingMessages.keys();
+    query.push({
+      type: "user",
+      message: { role: "user", content: "second" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: queuedUuid,
+      session_id: "s1",
+    });
+    await expect(promptA).resolves.toMatchObject({ stopReason: "end_turn" });
+
+    query.push(result({ uuid: "u-b-result" }));
+    query.push(idle("u-b-idle"));
+    await expect(promptB).resolves.toMatchObject({ stopReason: "end_turn" });
+    expect(session.pendingMessages.size).toBe(0);
 
     agent.sessions["s1"]!.abortController.abort();
     query.close();

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -36,9 +36,11 @@ import {
   describeAlwaysAllow,
   streamEventToAcpNotifications,
   messageIdForGrouping,
+  computeFollowupUsageUpdate,
   type SDKMessageFilter,
 } from "../acp-agent.js";
 import { Pushable } from "../utils.js";
+import { TurnQueue, OffTurnFollowupCollector } from "../session-reader.js";
 import {
   deleteSession,
   getSessionMessages,
@@ -46,6 +48,25 @@ import {
   SDKAssistantMessage,
 } from "@anthropic-ai/claude-agent-sdk";
 import { randomUUID } from "crypto";
+
+/** Test helper: arrange the per-session reader for an inline-injected
+ *  Session so prompt() has a producer feeding its turnQueue. Mirrors what
+ *  createSession() does in production. */
+function startReaderForTest(agent: ClaudeAcpAgent, sessionId: string): void {
+  const session = agent.sessions[sessionId];
+  if (!session) throw new Error(`startReaderForTest: session ${sessionId} not found`);
+  let resolveDone!: () => void;
+  session.readerDone = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+  void (
+    agent as unknown as {
+      startSessionReaderForTest(id: string, done: () => void): Promise<void>;
+    }
+  )
+    .startSessionReaderForTest(sessionId, resolveDone)
+    .catch(() => resolveDone());
+}
 
 vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
@@ -1708,7 +1729,15 @@ describe("stop reason propagation", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   it("should return max_tokens when success result has stop_reason max_tokens", async () => {
@@ -1854,7 +1883,15 @@ describe("stop reason propagation", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
 
     const response = await agent.prompt({
       sessionId: "test-session",
@@ -2015,7 +2052,15 @@ describe("session/close", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, sessionId);
     return agent.sessions[sessionId]!;
   }
 
@@ -2101,7 +2146,15 @@ describe("session/delete", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, sessionId);
     return agent.sessions[sessionId]!;
   }
 
@@ -2204,7 +2257,15 @@ describe("getOrCreateSession param change detection", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, sessionId);
     return agent.sessions[sessionId]!;
   }
 
@@ -2391,6 +2452,137 @@ describe("usage_update computation", () => {
     return { agent, updates };
   }
 
+  it("computes followup usage from buffered stream snapshots", () => {
+    const result = createResultMessageWithModel({
+      modelUsage: {
+        "claude-opus-4-20250514": {
+          inputTokens: 1000,
+          outputTokens: 500,
+          cacheReadInputTokens: 200,
+          cacheCreationInputTokens: 100,
+          webSearchRequests: 0,
+          costUSD: 0.01,
+          contextWindow: 1000000,
+          maxOutputTokens: 16384,
+        },
+      },
+    });
+    result.usage = {
+      input_tokens: 1,
+      output_tokens: 1,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+
+    const update = computeFollowupUsageUpdate(
+      [
+        createStreamEvent("message_start", {
+          model: "claude-opus-4-20250514",
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 0,
+            cache_read_input_tokens: 200,
+            cache_creation_input_tokens: 100,
+          },
+        }) as any,
+        createStreamEvent("message_delta", {
+          usage: { output_tokens: 500 },
+        }) as any,
+      ],
+      result as any,
+      200000,
+    );
+
+    expect(update).toEqual({ used: 1800, size: 1000000 });
+  });
+
+  it("falls back to result usage for followups without a buffered usage snapshot", () => {
+    const result = createResultMessageWithModel({ modelUsage: {} });
+    result.usage = {
+      input_tokens: 10,
+      output_tokens: 5,
+      cache_read_input_tokens: 2,
+      cache_creation_input_tokens: 1,
+    };
+
+    expect(computeFollowupUsageUpdate([], result as any, 200000)).toEqual({
+      used: 18,
+      size: 200000,
+    });
+  });
+
+  it("ignores subagent (non-top-level) messages and falls back to result usage", () => {
+    const result = createResultMessageWithModel({ modelUsage: {} });
+    result.usage = {
+      input_tokens: 30,
+      output_tokens: 7,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+
+    // Every buffered message belongs to a subagent (parent_tool_use_id set),
+    // so no top-level snapshot is captured and `used` falls back to
+    // result.usage rather than counting subagent token spend.
+    const update = computeFollowupUsageUpdate(
+      [
+        createStreamEvent(
+          "message_start",
+          {
+            model: "claude-opus-4-20250514",
+            usage: {
+              input_tokens: 99999,
+              output_tokens: 0,
+              cache_read_input_tokens: 0,
+              cache_creation_input_tokens: 0,
+            },
+          },
+          "subagent-tool-1",
+        ) as any,
+        createStreamEvent(
+          "message_delta",
+          { usage: { output_tokens: 88888 } },
+          "subagent-tool-1",
+        ) as any,
+      ],
+      result as any,
+      200000,
+    );
+
+    expect(update).toEqual({ used: 37, size: 200000 });
+  });
+
+  it("infers context window size when the model has no matching modelUsage key", () => {
+    // modelUsage doesn't contain the buffered model, so size resolution skips
+    // getMatchingModelUsage and uses inferContextWindowFromModel: a '[1m]'
+    // model infers 1,000,000 rather than the fallback.
+    const result = createResultMessageWithModel({ modelUsage: {} });
+    result.usage = {
+      input_tokens: 1,
+      output_tokens: 1,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    };
+
+    const update = computeFollowupUsageUpdate(
+      [
+        createStreamEvent("message_start", {
+          model: "claude-sonnet-4-6[1m]",
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+        }) as any,
+      ],
+      result as any,
+      200000,
+    );
+
+    expect(update.used).toBe(150);
+    expect(update.size).toBe(1000000);
+  });
+
   function injectSession(agent: ClaudeAcpAgent, messages: any[]) {
     const input = new Pushable<any>();
     async function* messageGenerator() {
@@ -2441,7 +2633,15 @@ describe("usage_update computation", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   it("used sums all token types as post-turn context occupancy proxy", async () => {
@@ -3450,7 +3650,15 @@ describe("assembled assistant text fallback", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   function messageChunkTexts(updates: any[]): string[] {
@@ -3646,7 +3854,15 @@ describe("emitRawSDKMessages", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   function createResultMessage() {
@@ -3876,7 +4092,15 @@ describe("result origin handling", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   function createAssistantMessage() {
@@ -4053,7 +4277,15 @@ describe("memory_recall handling", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
   }
 
   function createResult() {
@@ -4285,7 +4517,15 @@ describe("post-error recovery", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
     return { interrupt };
   }
 
@@ -4432,7 +4672,15 @@ describe("session/cancel wedge recovery (issue #680)", () => {
       taskState: new Map(),
       toolUseCache: {},
       messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn: new OffTurnFollowupCollector("test-session", async () => {}, {
+        log: () => {},
+        error: () => {},
+      }),
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
     };
+    startReaderForTest(agent, "test-session");
     return { interrupt };
   }
 
@@ -4732,5 +4980,1827 @@ describe("messageIdForGrouping", () => {
   it("returns undefined when there is no usable id", () => {
     expect(messageIdForGrouping({ type: "system", message: {} })).toBeUndefined();
     expect(messageIdForGrouping({ type: "assistant", uuid: "", message: {} })).toBeUndefined();
+  });
+});
+
+describe("session reader (issue #336)", () => {
+  // Single-consumer producer of SDK messages for the per-session reader.
+  // Tracks concurrent calls to assert the single-consumer invariant.
+  class QueryStub {
+    private queue: any[] = [];
+    private waiter: ((r: IteratorResult<any, void>) => void) | null = null;
+    private rejecter: ((err: unknown) => void) | null = null;
+    private closed = false;
+    private throwOnNextErr: unknown = undefined;
+    /** Highest number of `next()` calls that were simultaneously in flight. */
+    public maxConcurrentReads = 0;
+    private inFlight = 0;
+    /** Counts every `next()` invocation, including those that resolved
+     *  synchronously from the buffer. */
+    public nextCallCount = 0;
+
+    /** True when the producer queue is empty and the reader is parked on
+     *  next(). Tests use this to know the reader has caught up to the
+     *  most recent push before asserting reader-driven state. */
+    isIdle(): boolean {
+      return this.queue.length === 0 && this.waiter !== null;
+    }
+
+    push(item: any): void {
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        this.rejecter = null;
+        w({ value: item, done: false });
+      } else {
+        this.queue.push(item);
+      }
+    }
+    close(): void {
+      this.closed = true;
+      if (this.waiter) {
+        const w = this.waiter;
+        this.waiter = null;
+        this.rejecter = null;
+        w({ value: undefined as any, done: true });
+      }
+    }
+    throwOnNext(err: unknown): void {
+      this.throwOnNextErr = err;
+      if (this.rejecter) {
+        const r = this.rejecter;
+        this.waiter = null;
+        this.rejecter = null;
+        r(err);
+      }
+    }
+    next(): Promise<IteratorResult<any, void>> {
+      this.nextCallCount++;
+      this.inFlight++;
+      if (this.inFlight > this.maxConcurrentReads) {
+        this.maxConcurrentReads = this.inFlight;
+      }
+      const finish = <T>(v: T): T => {
+        this.inFlight--;
+        return v;
+      };
+      if (this.throwOnNextErr !== undefined) {
+        const err = this.throwOnNextErr;
+        this.throwOnNextErr = undefined;
+        this.inFlight--;
+        return Promise.reject(err);
+      }
+      if (this.queue.length > 0) {
+        const value = this.queue.shift()!;
+        this.inFlight--;
+        return Promise.resolve({ value, done: false });
+      }
+      if (this.closed) {
+        this.inFlight--;
+        return Promise.resolve({ value: undefined as any, done: true });
+      }
+      return new Promise<IteratorResult<any, void>>((resolve, reject) => {
+        this.waiter = (r) => {
+          finish(undefined);
+          resolve(r);
+        };
+        this.rejecter = (e) => {
+          finish(undefined);
+          reject(e);
+        };
+      });
+    }
+    // The session reader doesn't call these but production paths might.
+    interrupt(): Promise<void> {
+      return Promise.resolve();
+    }
+    closeQuery(): void {
+      this.closed = true;
+    }
+  }
+
+  function createCaptureClient() {
+    const sessionUpdates: Array<{ sessionId: string; update: any }> = [];
+    const extNotifications: Array<{ method: string; params: any }> = [];
+    const client = {
+      sessionUpdate: vi.fn(async (n: any) => {
+        sessionUpdates.push(n);
+      }),
+      extNotification: vi.fn(async (method: string, params: any) => {
+        extNotifications.push({ method, params });
+      }),
+    } as unknown as AgentSideConnection;
+    return { client, sessionUpdates, extNotifications };
+  }
+
+  function buildSession(
+    sessionId: string,
+    agent: ClaudeAcpAgent,
+    query: QueryStub,
+    input: Pushable<any>,
+    opts: { emitRawSDKMessages?: boolean; useRealFollowup?: boolean } = {},
+  ) {
+    // Default emitter is a no-op; tests that exercise followup forwarding
+    // replace `session.offTurn` with a collector bound to a capturing
+    // emitter (see the followup-forwarding tests below). With
+    // useRealFollowup the collector is bound to the production #emitFollowup
+    // so the end-to-end render path is exercised.
+    const emitter = opts.useRealFollowup
+      ? (msgs: any[], result: any) =>
+          (
+            agent as unknown as {
+              emitFollowupForTest(id: string, m: any[], r: any): Promise<void>;
+            }
+          ).emitFollowupForTest(sessionId, msgs, result)
+      : async () => {};
+    const offTurn = new OffTurnFollowupCollector(sessionId, emitter, {
+      log: () => {},
+      error: () => {},
+    });
+    const session = {
+      query: query as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      configOptions: [],
+      promptRunning: false,
+      pendingMessages: new Map(),
+      nextPendingOrder: 0,
+      abortController: new AbortController(),
+      emitRawSDKMessages: opts.emitRawSDKMessages ?? false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      toolUseCache: {},
+      messageIdToUuid: new Map(),
+      turnQueue: new TurnQueue(),
+      offTurn,
+      readerDone: Promise.resolve(),
+      readerSideEffects: Promise.resolve(),
+    };
+    agent.sessions[sessionId] = session as any;
+    startReaderForTest(agent, sessionId);
+    return session;
+  }
+
+  function createAgent(client: AgentSideConnection) {
+    return new ClaudeAcpAgent(client, { log: () => {}, error: () => {} });
+  }
+
+  it("forwards task_started using description (not summary) for the label", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      description: "ship the docs",
+      uuid: "u",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(1));
+    expect(sessionUpdates[0].update.sessionUpdate).toBe("agent_message_chunk");
+    // Wrapped in blank lines so back-to-back lifecycle chunks and following
+    // agent text don't fuse into one markdown paragraph.
+    expect(sessionUpdates[0].update.content.text).toBe("\n\n[task t1] started: ship the docs\n\n");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("forwards task_notification with the SDK status (no fallback to 'completed')", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t9",
+      status: "failed",
+      summary: "build broke",
+      output_file: "/tmp/9",
+      uuid: "u",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(1));
+    expect(sessionUpdates[0].update.content.text).toContain("[task t9] failed: build broke");
+    expect(sessionUpdates[0].update.content.text).toContain("output: /tmp/9");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("wraps lifecycle chunks in blank lines so back-to-back tasks stay separated", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    // Two notifications landing back-to-back (e.g. two background tasks
+    // finishing together) are the case that regressed: clients concatenate
+    // chunk text raw, so without blank-line wrapping they fuse into one line.
+    query.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      status: "completed",
+      summary: "first",
+      uuid: "u1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t2",
+      status: "completed",
+      summary: "second",
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(2));
+    // Each chunk is wrapped, so concatenating them yields a blank-line
+    // (paragraph) separator between the two tasks rather than a fused run.
+    const concatenated = sessionUpdates.map((u) => u.update.content.text).join("");
+    expect(concatenated).toContain("[task t1] completed: first\n\n");
+    expect(concatenated).toContain("\n\n[task t2] completed: second");
+    expect(concatenated).not.toContain("first[task t2]");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("suppresses lifecycle forward when skip_transcript=true", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t2",
+      status: "completed",
+      summary: "",
+      output_file: "",
+      skip_transcript: true,
+      uuid: "u",
+      session_id: "s1",
+    });
+    // Use a no-op message after the suppressed one to give the reader
+    // something to ack before we assert.
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t3",
+      description: "follow-up",
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(1));
+    expect(sessionUpdates[0].update.content.text).toContain("[task t3] started");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("emits raw SDK messages uniformly for both in-turn and off-turn", async () => {
+    const { client, extNotifications } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input, { emitRawSDKMessages: true });
+
+    // Off-turn lifecycle: reader should raw-emit.
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      description: "off-turn",
+      uuid: "u",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(extNotifications.length).toBe(1));
+    expect(extNotifications[0].method).toBe("_claude/sdkMessage");
+    expect(extNotifications[0].params.sessionId).toBe("s1");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("does not double-emit raw SDK messages for in-turn traffic", async () => {
+    // The reader is the only raw-emit site; prompt() no longer raw-emits.
+    // Verify that each in-turn message produces exactly one
+    // `_claude/sdkMessage` notification.
+    const { client, extNotifications } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input, { emitRawSDKMessages: true });
+
+    const promptDone = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+
+    // Replay + result + idle: three in-turn messages.
+    query.push({
+      type: "user",
+      message: { role: "user", content: "hi" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "ur",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "ures",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+
+    await promptDone;
+    await session.readerSideEffects;
+    // Three messages → exactly three raw-emit notifications, not six.
+    expect(extNotifications.length).toBe(3);
+    for (const n of extNotifications) {
+      expect(n.method).toBe("_claude/sdkMessage");
+    }
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("emits raw SDK messages in FIFO order (single side-effect chain)", async () => {
+    const { client, extNotifications } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input, { emitRawSDKMessages: true });
+
+    // Push several off-turn lifecycle messages; each is raw-emitted on the
+    // readerSideEffects chain. Order among raw emits must match push order.
+    for (let i = 0; i < 5; i++) {
+      query.push({
+        type: "system",
+        subtype: "task_started",
+        task_id: `t${i}`,
+        description: `task ${i}`,
+        uuid: `u${i}`,
+        session_id: "s1",
+      });
+    }
+
+    await vi.waitFor(() => expect(extNotifications.length).toBe(5));
+    const ids = extNotifications.map((n) => n.params.message.task_id);
+    expect(ids).toEqual(["t0", "t1", "t2", "t3", "t4"]);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("renders a real followup end-to-end via #emitFollowup (content + usage_update)", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    // useRealFollowup binds the off-turn collector to the production
+    // #emitFollowup so the actual render path runs (not a capturing stub).
+    const session = buildSession("s1", agent, query, input, { useRealFollowup: true });
+
+    // A followup: an assistant message carrying a tool_use block (text is
+    // filtered out since it would be streamed), closed by a task-notification
+    // result.
+    query.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [
+          { type: "text", text: "streamed-elsewhere" },
+          { type: "tool_use", id: "tu1", name: "Bash", input: { command: "ls" } },
+        ],
+        usage: {
+          input_tokens: 12,
+          output_tokens: 8,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: "a1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0.25,
+      usage: {
+        input_tokens: 12,
+        output_tokens: 8,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "r1",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    // Drain the detached side-effect chain that #emitFollowup runs on.
+    await session.readerSideEffects;
+
+    // The tool_use rendered as a tool_call, and a usage_update closed the
+    // followup with the task-notification origin in _meta.
+    const toolCalls = sessionUpdates.filter((u) => u.update.sessionUpdate === "tool_call");
+    expect(toolCalls.length).toBeGreaterThanOrEqual(1);
+    const usage = sessionUpdates.filter((u) => u.update.sessionUpdate === "usage_update");
+    expect(usage.length).toBe(1);
+    expect(usage[0].update.used).toBe(20); // 12 + 8 (+0 +0)
+    expect(usage[0].update.cost.amount).toBe(0.25);
+    expect(usage[0].update._meta?.["_claude/origin"]).toEqual({ kind: "task-notification" });
+    // The followup must not touch the user-turn accumulator.
+    expect(session.accumulatedUsage.inputTokens).toBe(0);
+    expect(session.accumulatedUsage.outputTokens).toBe(0);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("forwards a followup's assembled text when no content_block_delta streamed (non-streaming gateway)", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input, { useRealFollowup: true });
+
+    // A non-streaming gateway delivers the followup as one assembled assistant
+    // message with no preceding deltas. The text block is the only copy, so it
+    // must be forwarded rather than filtered. Mirrors #757 for the off-turn path.
+    query.push({
+      type: "assistant",
+      message: {
+        // A non-streaming gateway still stamps the assembled block with an API
+        // id. Include it so the dedup lookup runs against a real id (absent
+        // from streamedTextIds) rather than passing only because the set is
+        // empty — this guards the id-keying path, not just the empty-set case.
+        id: "msg-nonstream-1",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "the followup answer" }],
+        usage: {
+          input_tokens: 5,
+          output_tokens: 3,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: "a1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0.1,
+      usage: {
+        input_tokens: 5,
+        output_tokens: 3,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "r1",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    await session.readerSideEffects;
+
+    const texts = sessionUpdates
+      .filter((u) => u.update.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.update.content.text);
+    expect(texts).toContain("the followup answer");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("does not re-emit a followup's text that already streamed via content_block_delta", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input, { useRealFollowup: true });
+
+    // Normal streaming: the followup's deltas arrive, then the consolidated
+    // assistant message repeats the same text. The assembled block must be
+    // dropped so the client doesn't see it twice.
+    query.push({
+      type: "stream_event",
+      event: { type: "message_start", message: { id: "msg-fu", usage: {} } },
+      parent_tool_use_id: null,
+      uuid: "s0",
+      session_id: "s1",
+    });
+    query.push({
+      type: "stream_event",
+      event: {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "streamed answer" },
+      },
+      parent_tool_use_id: null,
+      uuid: "s1d",
+      session_id: "s1",
+    });
+    query.push({
+      type: "assistant",
+      message: {
+        id: "msg-fu",
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "text", text: "streamed answer" }],
+        usage: {
+          input_tokens: 5,
+          output_tokens: 3,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: "a1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0.1,
+      usage: {
+        input_tokens: 5,
+        output_tokens: 3,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "r1",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    await session.readerSideEffects;
+
+    // "streamed answer" reaches the client once (via the delta), not twice.
+    const occurrences = sessionUpdates
+      .filter((u) => u.update.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.update.content.text)
+      .filter((t) => t === "streamed answer");
+    expect(occurrences.length).toBe(1);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("forwards an autonomous task-notification followup out-of-turn", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    // Wire the off-turn collector to call the production #emitFollowup via
+    // an internal test-only adapter. Easier: replace the offTurn with one
+    // bound to a directly-spy emitter that captures.
+    const flushed: Array<{ msgs: any[]; result: any }> = [];
+    const session = buildSession("s1", agent, query, input);
+    session.offTurn = new OffTurnFollowupCollector(
+      "s1",
+      async (msgs, result) => {
+        flushed.push({ msgs, result });
+      },
+      { log: () => {}, error: () => {} },
+    );
+
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "followup body" }] },
+      parent_tool_use_id: null,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0.1,
+      usage: {
+        input_tokens: 10,
+        output_tokens: 5,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(flushed.length).toBe(1));
+    expect(flushed[0].msgs.length).toBe(1);
+    expect(flushed[0].msgs[0].type).toBe("assistant");
+    expect(flushed[0].result.origin.kind).toBe("task-notification");
+    expect(sessionUpdates.length).toBe(0); // followup is forwarded via the bound emitter, not sessionUpdate
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("does not contaminate the next user prompt's usage_update with a prior followup", async () => {
+    // The off-turn collector drains and forwards followups via its
+    // own emitter; the next prompt() starts with a fresh
+    // accumulatedUsage and never sees the followup messages in its loop.
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    // Drive a followup off-turn.
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "fu" }] },
+      parent_tool_use_id: null,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 1,
+      usage: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    // Wait for the reader to drain everything we pushed and park on next().
+    // Asserting on `session.offTurn.inspect().state === 'idle'` alone is
+    // not enough: the collector starts in 'idle' too, so the assertion can
+    // pass before the reader has consumed any message. Reader-parked + the
+    // collector having returned to idle is what we actually need.
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+
+    // Now run a real user turn. The reader should not replay any
+    // followup-tokens into accumulatedUsage.
+    const userTurnReplay = {
+      type: "user",
+      message: { role: "user", content: "hi" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u3",
+      session_id: "s1",
+    };
+    const turnResult = {
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "answer",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0.05,
+      usage: {
+        input_tokens: 7,
+        output_tokens: 3,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u4",
+      session_id: "s1",
+    };
+    const idle = {
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    };
+    // Push these so they're ready when prompt() starts.
+    query.push(userTurnReplay);
+    query.push(turnResult);
+    query.push(idle);
+
+    const r = await agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    expect(r.stopReason).toBe("end_turn");
+    expect(session.accumulatedUsage.inputTokens).toBe(7);
+    expect(session.accumulatedUsage.outputTokens).toBe(3);
+    // No "Please run /login" tripwire from a stale result, no usage_update
+    // with the followup's 1000+500.
+    const usageUpdates = sessionUpdates.filter((u) => u.update.sessionUpdate === "usage_update");
+    for (const u of usageUpdates) {
+      expect(u.update.used).not.toBe(1500);
+    }
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("does not throw authRequired for a followup result.result containing 'Please run /login'", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const flushed: any[] = [];
+    const session = buildSession("s1", agent, query, input);
+    session.offTurn = new OffTurnFollowupCollector(
+      "s1",
+      async (msgs, result) => {
+        flushed.push({ msgs, result });
+      },
+      { log: () => {}, error: () => {} },
+    );
+
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "Please run /login",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "u",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(flushed.length).toBe(1));
+    // The reader stayed up; no throw escaped.
+    expect(session.offTurn.inspect().state).toBe("idle");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("forwards lifecycle in the middle of a followup-candidate without breaking the FSM", async () => {
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const flushed: any[] = [];
+    const session = buildSession("s1", agent, query, input);
+    session.offTurn = new OffTurnFollowupCollector(
+      "s1",
+      async (msgs, result) => {
+        flushed.push({ msgs, result });
+      },
+      { log: () => {}, error: () => {} },
+    );
+
+    // Start a followup candidate.
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "a" }] },
+      parent_tool_use_id: null,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    // Lifecycle slips in mid-candidate — should be forwarded immediately,
+    // not added to the buffer.
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t2",
+      description: "concurrent",
+      uuid: "u2",
+      session_id: "s1",
+    });
+    // Close the candidate with a followup result.
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "u3",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(flushed.length).toBe(1));
+    // The lifecycle was forwarded as a sessionUpdate.
+    expect(sessionUpdates.some((u) => u.update.content?.text?.includes("[task t2] started"))).toBe(
+      true,
+    );
+    // The buffer contained only the assistant, not the lifecycle.
+    expect(flushed[0].msgs.length).toBe(1);
+    expect(flushed[0].msgs[0].type).toBe("assistant");
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("does not let a slow lifecycle sessionUpdate block a later prompt", async () => {
+    let releaseLifecycle!: () => void;
+    const lifecycleBlocked = new Promise<void>((resolve) => {
+      releaseLifecycle = resolve;
+    });
+    const client = {
+      sessionUpdate: vi.fn(async () => {
+        await lifecycleBlocked;
+      }),
+      extNotification: vi.fn(async () => {}),
+    } as unknown as AgentSideConnection;
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t-slow",
+      status: "completed",
+      summary: "slow client",
+      uuid: "u-slow",
+      session_id: "s1",
+    });
+    await vi.waitFor(() => expect(client.sessionUpdate).toHaveBeenCalledTimes(1));
+
+    const promptDone = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    query.push({
+      type: "user",
+      message: { role: "user", content: "hi" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 2,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u2",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      session_id: "s1",
+    });
+
+    await expect(promptDone).resolves.toMatchObject({ stopReason: "end_turn" });
+    releaseLifecycle();
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("clears queued turn leftovers after a prompt error", async () => {
+    let releaseFirstUpdate!: () => void;
+    let blockFirstUpdate = true;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    const { client } = createCaptureClient();
+    vi.mocked(client.sessionUpdate).mockImplementation(async () => {
+      if (blockFirstUpdate) {
+        blockFirstUpdate = false;
+        await firstUpdateBlocked;
+      }
+    });
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    const firstPrompt = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    query.push({
+      type: "system",
+      subtype: "local_command_output",
+      content: "blocking update",
+      uuid: "u-block",
+      session_id: "s1",
+    });
+    await vi.waitFor(() => expect(client.sessionUpdate).toHaveBeenCalledTimes(1));
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "Please run /login",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 100,
+        output_tokens: 100,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u-stale-result",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid: "u-stale-idle",
+      session_id: "s1",
+    });
+    await vi.waitFor(() => expect(session.turnQueue.size()).toBeGreaterThan(0));
+    releaseFirstUpdate();
+    await expect(firstPrompt).rejects.toThrow();
+    expect(session.turnQueue.size()).toBe(0);
+
+    const secondPrompt = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    query.push({
+      type: "user",
+      message: { role: "user", content: "second" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u-next-user",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 4,
+        output_tokens: 2,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u-next-result",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid: "u-next-idle",
+      session_id: "s1",
+    });
+
+    await expect(secondPrompt).resolves.toMatchObject({ stopReason: "end_turn" });
+    expect(session.accumulatedUsage.inputTokens).toBe(4);
+    expect(session.accumulatedUsage.outputTokens).toBe(2);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("discards orphan off-turn messages followed by an idle", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "x" }] },
+      parent_tool_use_id: null,
+      uuid: "u",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    // Wait until the reader has drained the queue and parked on next();
+    // only then is the buffer state reliable.
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    expect(session.offTurn.inspect().bufferSize).toBe(0);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("discards off-turn messages followed by a non-followup result", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const flushed: any[] = [];
+    const session = buildSession("s1", agent, query, input);
+    session.offTurn = new OffTurnFollowupCollector(
+      "s1",
+      async (msgs, result) => {
+        flushed.push({ msgs, result });
+      },
+      { log: () => {}, error: () => {} },
+    );
+
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "x" }] },
+      parent_tool_use_id: null,
+      uuid: "u",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      // No origin field → not a followup.
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    expect(flushed.length).toBe(0);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("cancellation aftermath is discarded by the reader, not replayed into the next turn", async () => {
+    // After a cancel() interrupt, the SDK can emit a tail of messages
+    // (a result with the interrupted turn and an idle). The reader sees
+    // them off-turn because prompt() already returned. The off-turn
+    // collector discards them — they must not contaminate the next user
+    // prompt's accumulatedUsage or stopReason.
+    const { client, sessionUpdates } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    // Run a turn, then send a cancelled idle so prompt() returns cancelled.
+    const firstPrompt = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "first" }],
+    });
+
+    query.push({
+      type: "user",
+      message: { role: "user", content: "first" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    // Simulate cancel mid-turn: cancelled=true + idle to end the turn.
+    session.cancelled = true;
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+    const first = await firstPrompt;
+    expect(first.stopReason).toBe("cancelled");
+
+    // Aftermath that the SDK might emit AFTER the interrupted turn ended.
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "stale" }] },
+      parent_tool_use_id: null,
+      uuid: "u2",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "error_during_execution",
+      is_error: false,
+      result: "interrupted",
+      stop_reason: "interrupted",
+      errors: [],
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 9999,
+        output_tokens: 9999,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u3",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+
+    // Wait for the reader to drain the aftermath.
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+
+    // Reset session.cancelled and run the next user turn cleanly.
+    session.cancelled = false;
+    const secondPrompt = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    query.push({
+      type: "user",
+      message: { role: "user", content: "second" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u4",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 4,
+        output_tokens: 2,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "u5",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+
+    const second = await secondPrompt;
+    expect(second.stopReason).toBe("end_turn");
+    // The aftermath's 9999/9999 must not be in the second turn's usage.
+    expect(session.accumulatedUsage.inputTokens).toBe(4);
+    expect(session.accumulatedUsage.outputTokens).toBe(2);
+    // And no usage_update was emitted for the aftermath result.
+    const usageUpdates = sessionUpdates.filter((u) => u.update.sessionUpdate === "usage_update");
+    for (const u of usageUpdates) {
+      expect(u.update.used).not.toBe(9999 * 2);
+    }
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("process-died throw in reader propagates to the active prompt as an error", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    const promptPromise = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    // Give the reader a chance to grab its first next() and prompt() a
+    // chance to set promptRunning + start awaiting turnQueue.
+    await new Promise((r) => setTimeout(r, 5));
+
+    query.throwOnNext(new Error("process exited with code 1"));
+
+    await expect(promptPromise).rejects.toBeInstanceOf(Error);
+
+    // Session entry should have been cleaned up by the process-died path.
+    expect(agent.sessions["s1"]).toBeUndefined();
+  });
+
+  it("tears down the session when the reader dies on a non-process-death iterator error", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    const promptPromise = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    await new Promise((r) => setTimeout(r, 5));
+
+    // An error whose message matches none of the process-death substrings.
+    // The reader errors the turnQueue and exits; without teardown the queue's
+    // latched error would brick every future prompt() on this session.
+    query.throwOnNext(new Error("Unexpected event order, got delta before message_start"));
+
+    await expect(promptPromise).rejects.toBeInstanceOf(Error);
+    // The dead reader can never feed this session again, so it must be removed
+    // rather than left in the map with a permanently errored queue. See #336.
+    expect(agent.sessions["s1"]).toBeUndefined();
+  });
+
+  it("returns cancelled (not an error) when a force-cancel races an iterator throw", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    const promptPromise = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Reproduce the race where the take() rejection wins: cancel() has set
+    // session.cancelled but the force-cancel timer has NOT yet aborted the
+    // wake-up channel (so the `cancelled` promise never resolves), and the
+    // iterator throws. The rejection propagates through Promise.race into the
+    // catch, bypassing the line-level aborted check. The catch must still
+    // honor the cancel contract via session.cancelled and return "cancelled"
+    // rather than surfacing the trailing error as an internal error. See
+    // #680/#336.
+    session.cancelled = true;
+    query.throwOnNext(new Error("stream has ended, this shouldn't happen"));
+
+    await expect(promptPromise).resolves.toEqual({ stopReason: "cancelled" });
+  });
+
+  it("teardownSession awaits the reader before deleting the session entry", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+    const readerDone = agent.sessions["s1"]!.readerDone;
+
+    let resolved = false;
+    void readerDone.then(() => {
+      resolved = true;
+    });
+
+    // teardownSession is private; reach it via the public closeSession.
+    const teardownPromise = (
+      agent as unknown as { teardownSession(id: string): Promise<void> }
+    ).teardownSession("s1");
+
+    // The reader exits when query.close() fires from teardown; resolve it.
+    query.close();
+    await teardownPromise;
+    expect(resolved).toBe(true);
+    expect(agent.sessions["s1"]).toBeUndefined();
+  });
+
+  it("drops queued reader side effects after the session entry is replaced", async () => {
+    let releaseFirstUpdate!: () => void;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    const { client, sessionUpdates } = createCaptureClient();
+    vi.mocked(client.sessionUpdate).mockImplementation(async (n: any) => {
+      sessionUpdates.push(n);
+      if (sessionUpdates.length === 1) {
+        await firstUpdateBlocked;
+      }
+    });
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const oldSession = buildSession("s1", agent, query, input);
+
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "old-1",
+      description: "already running",
+      uuid: "u1",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "old-2",
+      description: "queued stale side effect",
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(1));
+
+    oldSession.abortController.abort();
+    query.close();
+    delete agent.sessions["s1"];
+
+    const replacementQuery = new QueryStub();
+    const replacementInput = new Pushable<any>();
+    const replacementSession = buildSession("s1", agent, replacementQuery, replacementInput);
+
+    releaseFirstUpdate();
+    await oldSession.readerSideEffects;
+    await Promise.resolve();
+
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].update.content.text).toContain("[task old-1]");
+
+    replacementSession.abortController.abort();
+    replacementQuery.close();
+  });
+
+  it("teardownSession drains a pending reader side effect before deleting the session", async () => {
+    let releaseUpdate!: () => void;
+    let updateStarted = false;
+    const { client, sessionUpdates } = createCaptureClient();
+    vi.mocked(client.sessionUpdate).mockImplementation(async (n: any) => {
+      sessionUpdates.push(n);
+      updateStarted = true;
+      await new Promise<void>((resolve) => {
+        releaseUpdate = resolve;
+      });
+    });
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    // A lifecycle message schedules a (slow) sessionUpdate on the detached
+    // readerSideEffects chain.
+    query.push({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      description: "slow",
+      uuid: "u1",
+      session_id: "s1",
+    });
+    await vi.waitFor(() => expect(updateStarted).toBe(true));
+
+    let teardownResolved = false;
+    const teardownPromise = (agent as unknown as { teardownSession(id: string): Promise<void> })
+      .teardownSession("s1")
+      .then(() => {
+        teardownResolved = true;
+      });
+    query.close();
+
+    // readerDone resolves quickly (reader loop exits on close), but the
+    // side-effect chain is still blocked on the slow sessionUpdate, so
+    // teardown must not have resolved yet.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(teardownResolved).toBe(false);
+
+    releaseUpdate();
+    await teardownPromise;
+    expect(teardownResolved).toBe(true);
+    expect(agent.sessions["s1"]).toBeUndefined();
+  });
+
+  it("stops a multi-update followup side effect if the session entry is replaced mid-emit", async () => {
+    let releaseFirstUpdate!: () => void;
+    const firstUpdateBlocked = new Promise<void>((resolve) => {
+      releaseFirstUpdate = resolve;
+    });
+    const { client, sessionUpdates } = createCaptureClient();
+    vi.mocked(client.sessionUpdate).mockImplementation(async (n: any) => {
+      sessionUpdates.push(n);
+      if (sessionUpdates.length === 1) {
+        await firstUpdateBlocked;
+      }
+    });
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const oldSession = buildSession("s1", agent, query, input, { useRealFollowup: true });
+
+    query.push({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        model: "claude-sonnet-4-6",
+        content: [{ type: "tool_use", id: "tu-stale", name: "Bash", input: { command: "pwd" } }],
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+        },
+      },
+      parent_tool_use_id: null,
+      uuid: "a-stale",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "done",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      origin: { kind: "task-notification" },
+      uuid: "r-stale",
+      session_id: "s1",
+    });
+
+    await vi.waitFor(() => expect(sessionUpdates.length).toBe(1));
+    oldSession.abortController.abort();
+    query.close();
+    delete agent.sessions["s1"];
+
+    const replacementQuery = new QueryStub();
+    const replacementInput = new Pushable<any>();
+    const replacementSession = buildSession("s1", agent, replacementQuery, replacementInput);
+
+    releaseFirstUpdate();
+    await oldSession.readerSideEffects;
+
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].update.sessionUpdate).toBe("tool_call");
+
+    replacementSession.abortController.abort();
+    replacementQuery.close();
+  });
+
+  it("drops leftover in-turn messages from the turnQueue when a turn is cancelled", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    const promptPromise = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    await vi.waitFor(() => expect(session.promptRunning).toBe(true));
+
+    // The reader delivers the replay (consumed by prompt), then the SDK
+    // emits the cancelled idle followed by trailing aftermath. The prompt
+    // returns on the idle; the aftermath must not survive into the next turn.
+    query.push({
+      type: "user",
+      message: { role: "user", content: "hi" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "u1",
+      session_id: "s1",
+    });
+    session.cancelled = true;
+    query.push({ type: "system", subtype: "session_state_changed", state: "idle" });
+    query.push({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "stale" }] },
+      parent_tool_use_id: null,
+      uuid: "u2",
+      session_id: "s1",
+    });
+
+    const r = await promptPromise;
+    expect(r.stopReason).toBe("cancelled");
+
+    // The trailing aftermath arrives off-turn; its closing idle lets the
+    // collector discard it.
+    query.push({ type: "system", subtype: "session_state_changed", state: "idle" });
+    await vi.waitFor(() => {
+      expect(query.isIdle()).toBe(true);
+      expect(session.offTurn.inspect().state).toBe("idle");
+    });
+    // No leftover in the turnQueue from the cancelled turn, and the off-turn
+    // collector discarded the aftermath rather than holding it for replay.
+    expect(session.turnQueue.size()).toBe(0);
+    expect(session.offTurn.inspect().bufferSize).toBe(0);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("single-consumer invariant: only one query.next() can be in flight", async () => {
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    buildSession("s1", agent, query, input);
+
+    // Push a few messages and let the reader drain them.
+    for (let i = 0; i < 5; i++) {
+      query.push({
+        type: "system",
+        subtype: "task_started",
+        task_id: `t${i}`,
+        description: `task ${i}`,
+        uuid: `u${i}`,
+        session_id: "s1",
+      });
+    }
+    await vi.waitFor(() => expect(query.nextCallCount).toBeGreaterThanOrEqual(5));
+    expect(query.maxConcurrentReads).toBe(1);
+
+    // Even with a concurrent prompt() and the reader cycling, only one
+    // next() at a time.
+    const promptDone = agent.prompt({
+      sessionId: "s1",
+      prompt: [{ type: "text", text: "hi" }],
+    });
+    query.push({
+      type: "user",
+      message: { role: "user", content: "hi" },
+      parent_tool_use_id: null,
+      isReplay: true,
+      uuid: "ur",
+      session_id: "s1",
+    });
+    query.push({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: 1,
+        output_tokens: 1,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid: "urr",
+      session_id: "s1",
+    });
+    query.push({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+    await promptDone;
+    expect(query.maxConcurrentReads).toBe(1);
+
+    agent.sessions["s1"]!.abortController.abort();
+    query.close();
+  });
+
+  it("resumes a queued prompt with promptRunning re-asserted when the prior turn ends without replaying it (#336)", async () => {
+    // Regression: a prompt queued behind a running turn can be resumed via the
+    // finally-fallback in prompt() (the prior turn ended at idle without ever
+    // replaying the queued user message). That fallback sets promptRunning=false
+    // and *then* resolves the waiter, so the resumed prompt must re-assert
+    // promptRunning before reading the turnQueue. If it doesn't, the reader
+    // routes the resumed turn's messages off-turn (where the followup collector
+    // discards them) and the prompt hangs forever.
+    const { client } = createCaptureClient();
+    const agent = createAgent(client);
+    const query = new QueryStub();
+    const input = new Pushable<any>();
+    const session = buildSession("s1", agent, query, input);
+
+    const result = (usage: { input: number; output: number }, uuid: string) => ({
+      type: "result",
+      subtype: "success",
+      is_error: false,
+      result: "ok",
+      stop_reason: "end_turn",
+      num_turns: 1,
+      duration_ms: 1,
+      duration_api_ms: 1,
+      total_cost_usd: 0,
+      usage: {
+        input_tokens: usage.input,
+        output_tokens: usage.output,
+        cache_read_input_tokens: 0,
+        cache_creation_input_tokens: 0,
+      },
+      modelUsage: {},
+      permission_denials: [],
+      uuid,
+      session_id: "s1",
+    });
+    const idle = (uuid: string) => ({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+      uuid,
+      session_id: "s1",
+    });
+
+    // Prompt A takes the stream (else branch -> promptRunning=true).
+    const promptA = agent.prompt({ sessionId: "s1", prompt: [{ type: "text", text: "A" }] });
+    await vi.waitFor(() => expect(session.promptRunning).toBe(true));
+
+    // Prompt B arrives while A is running -> queued in pendingMessages.
+    const promptB = agent.prompt({ sessionId: "s1", prompt: [{ type: "text", text: "B" }] });
+    await vi.waitFor(() => expect(session.pendingMessages.size).toBe(1));
+
+    // A ends at idle without B's user message ever being replayed, so A never
+    // hands off; its finally resolves B through the fallback path.
+    query.push(result({ input: 0, output: 0 }, "u-a-result"));
+    query.push(idle("u-a-idle"));
+    await expect(promptA).resolves.toMatchObject({ stopReason: "end_turn" });
+
+    // The fix: B re-asserts promptRunning on resume. Without it this stays
+    // false (the fallback cleared it) and the assertion times out.
+    await vi.waitFor(() => expect(session.promptRunning).toBe(true));
+
+    // B's own turn is now routed into the turnQueue and consumed, not misrouted
+    // off-turn. B resolves with its result and its usage is accounted for.
+    query.push(result({ input: 7, output: 3 }, "u-b-result"));
+    query.push(idle("u-b-idle"));
+    await expect(promptB).resolves.toMatchObject({ stopReason: "end_turn" });
+    expect(session.accumulatedUsage.inputTokens).toBe(7);
+    expect(session.accumulatedUsage.outputTokens).toBe(3);
+
+    // Only the reader ever consumed the SDK iterator throughout the handoff.
+    expect(query.maxConcurrentReads).toBe(1);
+
+    session.abortController.abort();
+    query.close();
   });
 });

--- a/src/tests/session-reader.test.ts
+++ b/src/tests/session-reader.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, expect, vi } from "vitest";
+import type {
+  SDKMessage,
+  SDKResultMessage,
+  SDKTaskNotificationMessage,
+  SDKTaskStartedMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import { TurnQueue, OffTurnFollowupCollector, classifyOffTurn } from "../session-reader.js";
+
+function silentLogger() {
+  return { log: vi.fn(), error: vi.fn() };
+}
+
+// Build the smallest SDKMessage shape vitest will accept. We cast to the
+// real type via `as unknown as SDKMessage` so call sites stay strongly
+// typed.
+function asMessage<T extends Record<string, unknown>>(m: T): SDKMessage {
+  return m as unknown as SDKMessage;
+}
+
+describe("TurnQueue", () => {
+  it("returns a message pushed before take()", async () => {
+    const q = new TurnQueue();
+    q.push(asMessage({ type: "assistant", uuid: "1", session_id: "s" }));
+    const r = await q.take();
+    expect(r.done).toBe(false);
+    expect((r.value as { type: string }).type).toBe("assistant");
+  });
+
+  it("resolves the consumer when push happens after take()", async () => {
+    const q = new TurnQueue();
+    const p = q.take();
+    q.push(asMessage({ type: "user", uuid: "2", session_id: "s" }));
+    const r = await p;
+    expect(r.done).toBe(false);
+    expect((r.value as { type: string }).type).toBe("user");
+  });
+
+  it("preserves FIFO order", async () => {
+    const q = new TurnQueue();
+    q.push(asMessage({ type: "a", n: 1 }));
+    q.push(asMessage({ type: "b", n: 2 }));
+    q.push(asMessage({ type: "c", n: 3 }));
+    expect(((await q.take()).value as { n: number }).n).toBe(1);
+    expect(((await q.take()).value as { n: number }).n).toBe(2);
+    expect(((await q.take()).value as { n: number }).n).toBe(3);
+  });
+
+  it("returns done:true on take() after close()", async () => {
+    const q = new TurnQueue();
+    q.close();
+    const r = await q.take();
+    expect(r.done).toBe(true);
+  });
+
+  it("resolves a pending take() with done:true when close() arrives", async () => {
+    const q = new TurnQueue();
+    const p = q.take();
+    q.close();
+    const r = await p;
+    expect(r.done).toBe(true);
+  });
+
+  it("rejects a pending take() when error() arrives", async () => {
+    const q = new TurnQueue();
+    const p = q.take();
+    q.error(new Error("boom"));
+    await expect(p).rejects.toThrow("boom");
+  });
+
+  it("rejects subsequent take() after error() with no pending waiter", async () => {
+    const q = new TurnQueue();
+    q.error(new Error("nope"));
+    await expect(q.take()).rejects.toThrow("nope");
+  });
+
+  it("throws on concurrent take()", () => {
+    const q = new TurnQueue();
+    void q.take();
+    expect(() => q.take()).toThrow(/concurrent take/);
+  });
+
+  it("drops messages pushed after close() instead of throwing", async () => {
+    const q = new TurnQueue();
+    q.close();
+    q.push(asMessage({ type: "a" }));
+    const r = await q.take();
+    expect(r.done).toBe(true);
+  });
+
+  it("close() and error() are idempotent", async () => {
+    const q1 = new TurnQueue();
+    q1.close();
+    q1.close();
+    expect((await q1.take()).done).toBe(true);
+
+    const q2 = new TurnQueue();
+    q2.error(new Error("first"));
+    q2.error(new Error("second"));
+    await expect(q2.take()).rejects.toThrow("first");
+  });
+
+  it("delivers buffered messages before reporting close() to consumer", async () => {
+    const q = new TurnQueue();
+    q.push(asMessage({ type: "a", n: 1 }));
+    q.push(asMessage({ type: "b", n: 2 }));
+    q.close();
+    expect(((await q.take()).value as { n: number }).n).toBe(1);
+    expect(((await q.take()).value as { n: number }).n).toBe(2);
+    expect((await q.take()).done).toBe(true);
+  });
+
+  it("clear() drops buffered messages without closing the queue", async () => {
+    const q = new TurnQueue();
+    q.push(asMessage({ type: "a" }));
+    q.push(asMessage({ type: "b" }));
+    q.clear();
+    const p = q.take();
+    q.push(asMessage({ type: "c" }));
+    const r = await p;
+    expect(r.done).toBe(false);
+    expect((r.value as { type: string }).type).toBe("c");
+  });
+});
+
+describe("classifyOffTurn", () => {
+  it("classifies task_started as lifecycle", () => {
+    const m = asMessage<Partial<SDKTaskStartedMessage>>({
+      type: "system",
+      subtype: "task_started",
+      task_id: "t1",
+      description: "do thing",
+    });
+    expect(classifyOffTurn(m)).toBe("lifecycle");
+  });
+
+  it("classifies task_notification as lifecycle", () => {
+    const m = asMessage<Partial<SDKTaskNotificationMessage>>({
+      type: "system",
+      subtype: "task_notification",
+      task_id: "t1",
+      status: "completed",
+      summary: "ok",
+      output_file: "/tmp/x",
+    });
+    expect(classifyOffTurn(m)).toBe("lifecycle");
+  });
+
+  it("classifies session_state_changed:idle as followup-candidate (collector handles it)", () => {
+    const m = asMessage({
+      type: "system",
+      subtype: "session_state_changed",
+      state: "idle",
+    });
+    expect(classifyOffTurn(m)).toBe("followup-candidate");
+  });
+
+  it("classifies assistant as followup-candidate", () => {
+    expect(classifyOffTurn(asMessage({ type: "assistant" }))).toBe("followup-candidate");
+  });
+
+  it("classifies result as followup-candidate", () => {
+    expect(classifyOffTurn(asMessage({ type: "result" }))).toBe("followup-candidate");
+  });
+
+  it("classifies stream_event as followup-candidate", () => {
+    expect(classifyOffTurn(asMessage({ type: "stream_event" }))).toBe("followup-candidate");
+  });
+
+  it("classifies other system subtypes as followup-candidate", () => {
+    expect(classifyOffTurn(asMessage({ type: "system", subtype: "hook_progress" }))).toBe(
+      "followup-candidate",
+    );
+  });
+});
+
+describe("OffTurnFollowupCollector", () => {
+  function setup(emitFollowup?: ReturnType<typeof vi.fn>) {
+    const logger = silentLogger();
+    const emit = emitFollowup ?? vi.fn().mockResolvedValue(undefined);
+    const c = new OffTurnFollowupCollector(
+      "s1",
+      emit as unknown as (msgs: SDKMessage[], result: SDKResultMessage) => Promise<void>,
+      logger,
+    );
+    return { c, emit, logger };
+  }
+
+  it("starts in idle state with empty buffer", () => {
+    const { c } = setup();
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+
+  it("accumulates non-terminal messages and moves to collecting state", async () => {
+    const { c } = setup();
+    await c.accept(asMessage({ type: "assistant", n: 1 }));
+    expect(c.inspect()).toEqual({ state: "collecting", bufferSize: 1 });
+    await c.accept(asMessage({ type: "stream_event", n: 2 }));
+    expect(c.inspect()).toEqual({ state: "collecting", bufferSize: 2 });
+  });
+
+  it("emits followup when result has origin.kind=task-notification", async () => {
+    const { c, emit } = setup();
+    await c.accept(asMessage({ type: "assistant", n: 1 }));
+    await c.accept(asMessage({ type: "stream_event", n: 2 }));
+    const result = asMessage<Partial<SDKResultMessage>>({
+      type: "result",
+      origin: { kind: "task-notification" },
+    });
+    await c.accept(result);
+    expect(emit).toHaveBeenCalledTimes(1);
+    const [bufferedArg, resultArg] = emit.mock.calls[0];
+    expect((bufferedArg as SDKMessage[]).length).toBe(2);
+    expect(resultArg).toBe(result);
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+
+  it("discards buffer with log when result has no task-notification origin", async () => {
+    const { c, emit, logger } = setup();
+    await c.accept(asMessage({ type: "assistant", n: 1 }));
+    await c.accept(asMessage({ type: "result" }));
+    expect(emit).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining("discarding 1 off-turn messages followed by non-followup result"),
+    );
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+
+  it("discards buffer with log on session_state_changed:idle without closing result", async () => {
+    const { c, emit, logger } = setup();
+    await c.accept(asMessage({ type: "assistant", n: 1 }));
+    await c.accept(asMessage({ type: "stream_event", n: 2 }));
+    await c.accept(
+      asMessage({
+        type: "system",
+        subtype: "session_state_changed",
+        state: "idle",
+      }),
+    );
+    expect(emit).not.toHaveBeenCalled();
+    expect(logger.log).toHaveBeenCalledWith(
+      expect.stringContaining("discarding 2 off-turn messages with no closing result"),
+    );
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+
+  it("idle with empty buffer is a silent no-op", async () => {
+    const { c, logger } = setup();
+    await c.accept(
+      asMessage({
+        type: "system",
+        subtype: "session_state_changed",
+        state: "idle",
+      }),
+    );
+    expect(logger.log).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-idle session_state_changed (treats as candidate)", async () => {
+    const { c } = setup();
+    await c.accept(
+      asMessage({
+        type: "system",
+        subtype: "session_state_changed",
+        state: "running",
+      }),
+    );
+    expect(c.inspect().bufferSize).toBe(1);
+  });
+
+  it("emits followup with an empty buffer if the result arrives standalone", async () => {
+    const { c, emit } = setup();
+    await c.accept(
+      asMessage<Partial<SDKResultMessage>>({
+        type: "result",
+        origin: { kind: "task-notification" },
+      }),
+    );
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect((emit.mock.calls[0][0] as SDKMessage[]).length).toBe(0);
+  });
+
+  it("drops oldest entry and logs error when buffer cap is reached", async () => {
+    const { c, logger } = setup();
+    for (let i = 0; i < 257; i++) {
+      await c.accept(asMessage({ type: "assistant", n: i }));
+    }
+    expect(c.inspect().bufferSize).toBe(256);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("off-turn followup buffer cap reached"),
+    );
+  });
+
+  it("swallows and logs emitFollowup errors without throwing to the reader", async () => {
+    const failingEmit = vi.fn().mockRejectedValue(new Error("network down"));
+    const { c, logger } = setup(failingEmit);
+    await c.accept(asMessage({ type: "assistant", n: 1 }));
+    await expect(
+      c.accept(
+        asMessage<Partial<SDKResultMessage>>({
+          type: "result",
+          origin: { kind: "task-notification" },
+        }),
+      ),
+    ).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining("emitFollowup failed"),
+      expect.any(Error),
+    );
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+
+  it("reset() clears any buffered candidates", async () => {
+    const { c } = setup();
+    await c.accept(asMessage({ type: "assistant" }));
+    await c.accept(asMessage({ type: "stream_event" }));
+    c.reset();
+    expect(c.inspect()).toEqual({ state: "idle", bufferSize: 0 });
+  });
+});


### PR DESCRIPTION
Fixes #336.

## Summary

When Claude Code launches background tasks via the `Task` tool with `run_in_background=true`, `task_notification` (and `task_started`) system messages arriving between turns sit in the SDK's internal buffer until the user sends the next message — at which point the wrapper's `prompt()` switch hits the `// Todo: process via status api` no-op and silently discards them. The user observes this as "the agent doesn't react to my background task completing — I have to type something to wake it, and then it acts on a stale prompt".

The wrapper now runs a **single-consumer session reader** per session that is the sole consumer of `session.query`. It forwards `task_started` / `task_notification` to the ACP client the moment they arrive (in-turn or between turns), hands in-turn messages to the active `prompt()` via a queue, and forwards autonomous `task-notification` followups out-of-turn. `prompt()` no longer touches the SDK iterator directly.

> An earlier revision of this PR implemented the issue's "Option B" sketch as a background **drain** that shared the SDK `AsyncGenerator` with `prompt()` via a cooperative lock (`drainedBuffer` / `drainReadInFlight` / `onPromptIdle`). An adversarial review found that sharing one `AsyncGenerator` between two consumers is fragile by construction (≈15 findings: orphaned `Promise.race` reads, stale buffered messages leaking into the next turn, client-latency coupling, missing abort on process-death, etc.). The drain was replaced with the single-consumer design described below.

## Architecture

A new module `src/session-reader.ts` holds three unit-testable building blocks:

- **`TurnQueue`** — single-producer / single-consumer async queue. The reader is the only producer; `prompt()` is the only consumer per turn. `close()` / `error()` propagate to the consumer; `clear()` drops leftovers for an abandoned turn.
- **`classifyOffTurn`** — pure classifier: a message is either `lifecycle` (emit immediately) or a `followup-candidate` (feed to the collector).
- **`OffTurnFollowupCollector`** — small state machine for messages seen while no turn is active. It buffers followup candidates until the closing `result`/`idle`, then forwards them (when `result.origin.kind === "task-notification"`) or discards them as aftermath. Bounded by a 256-entry cap.

In `src/acp-agent.ts`:

- **`#runSessionReader`** — the only caller of `session.query.next()`. Per message: optionally schedule a raw-SDK emit; if lifecycle, emit it; else if a turn is running, push to `turnQueue`; else feed `offTurn`. Exits cleanly on abort / iterator close / iterator throw, closing the queue so any consumer is unblocked.
- **`#enqueueReaderSideEffect`** — serializes the reader's client-facing emits (raw SDK messages, lifecycle, followup) onto a per-session promise chain the reader **never awaits**, so a slow ACP client can't stall SDK consumption or block the next prompt.
- **`#emitTaskLifecycleUpdate`** — renders `task_started` (using the SDK's `description`) and `task_notification` (using the SDK's real `status`) as an `agent_message_chunk`, routed to the reader's bound `sessionId`.
- **`#emitFollowup`** / **`computeFollowupUsageUpdate`** — forward an autonomous followup's content using the same notification helpers `prompt()` uses, plus a `usage_update` derived from the followup's own snapshots, without ever touching `accumulatedUsage`, `stopReason`, or the user's pending prompts.
- **`prompt()`** consumes `session.turnQueue.take()` instead of `session.query.next()`. Raw-SDK emit moved entirely to the reader (no double-emit). Error/cancel paths clear the queue.

## Behaviour

- `task_started` / `task_notification` produce a short bracketed `agent_message_chunk` — `[task <id>] started: <description>` or `[task <id>] <status>: <summary>` plus `output: <path>` when present — whether the event arrives during a turn or between turns.
- `skip_transcript: true` lifecycle messages produce no client-visible update.
- Autonomous `task-notification` followups (an SDK-driven mini-turn that runs between user turns) are forwarded to the client out-of-turn: their assistant/tool content via the normal notification helpers, plus a `usage_update` carrying the followup's cost and `_claude/origin` meta. They never contaminate the next user turn's usage or stop reason.
- Non-followup off-turn aftermath (e.g. the tail of a cancelled or errored turn) is discarded with a debug log, never replayed into the next prompt.
- A followup's assembled text/thinking blocks are deduped against what actually streamed live (per message id), and un-streamed blocks are forwarded as a fallback, so a followup behind a non-streaming gateway still delivers its final answer — mirroring the in-turn handling from #757.

## Lifecycle & robustness

- **Single consumer.** Only the reader calls `session.query.next()`, eliminating the concurrent-`next()`-on-an-AsyncGenerator hazard.
- **Teardown.** `teardownSession` and the process-died recovery `abort()`, then wait for the reader and drain its detached `readerSideEffects` chain (both bounded by a 2s timeout, via `#drainReader`) before deleting the session — so queued emits finish before the session disappears and a wedged SDK iterator (issue #680) can't hang teardown on an unbounded `await readerDone`.
- **Reader-death recovery.** The reader is the sole consumer and is spawned once, so a `TurnQueue` left in a terminal state (iterator threw a non-process-death error, or returned done mid-session) means the reader is gone and can never feed the session again. `prompt()` detects this (`turnQueue.isTerminal()`) and tears the session down so the client starts fresh, rather than every future prompt failing on the latched error.
- **Cancellation.** `prompt()` clears the `turnQueue` on both error and cancel, so messages the reader buffered for an abandoned turn don't leak into the next one. A force-cancel that races an iterator throw (the rejection winning the `take()` vs. wake-up race) still returns `stopReason: "cancelled"` rather than surfacing the trailing error.
- **Interrupt & send cancellation.** `cancel()` now keeps a separate `interrupted` flag while a turn is winding down, so a queued follow-up prompt can reset `cancelled` without turning the interrupted turn's late `is_error` result into an Internal error or cancelling the queued prompt.
- **Raw-SDK ordering contract.** Raw `_claude/sdkMessage` emits are FIFO among themselves but are explicitly **not** ordered relative to the derived `session/update` stream (the reader doesn't block on the client). Documented at the emit site.

## Tests

`npm run test:run`: **419 passed | 15 skipped**.

- `src/tests/session-reader.test.ts` — unit tests for `TurnQueue` (push/take/close/error/clear, FIFO, concurrent-take guard), `classifyOffTurn` (every subtype), `OffTurnFollowupCollector` (all transitions, cap, emit-error swallowing).
- `src/tests/acp-agent.test.ts` → `describe("session reader (issue #336)")` — lifecycle (`description` not `summary`; real `status`; `skip_transcript`), raw-SDK emit (off-turn, no in-turn double-emit, FIFO order), followup forwarding (out-of-turn, no usage contamination, no `authRequired` from a stale `Please run /login`, lifecycle-mid-followup, real `#emitFollowup` end-to-end render), aftermath (orphan+idle, non-followup result, cancellation aftermath discarded), process-died propagation, teardown awaits reader + drains side-effects, single-consumer invariant.
- `computeFollowupUsageUpdate` unit cases: buffered snapshot, fallback to `result.usage`, subagent-only fallback, model with no matching `modelUsage` key → inferred context window.
- Regression coverage added during review/rebase: a non-process-death iterator error tears the session down (no permanent brick); a force-cancel racing an iterator throw returns `cancelled`; an interrupt-and-send late `is_error` result is treated as cancellation after a queued prompt resets `cancelled`; a followup's assembled text is forwarded when nothing streamed and deduped when it did (the #757 alignment for the off-turn path).

## Verification

```
npm run build         # tsc, clean
npm run check         # eslint + prettier, clean
npm run test:run      # 419 passed | 15 skipped
```

## Out of scope (deliberately not in this PR)

Two product enhancements were considered and **intentionally left out**:

1. **Live streaming of autonomous followups.** Today a followup's content is buffered and forwarded as a block when its closing `result` arrives. Streaming it token-by-token is **blocked by the SDK contract, not by effort**: only the `result` message carries `origin`; the `assistant` / `stream_event` content messages do not. To stream we'd have to emit content before knowing whether the group is a real followup or the aftermath of a cancelled/errored turn — and emitting aftermath optimistically reintroduces exactly the contamination this PR fixes, with no way to retract it over ACP. A safe implementation needs either (a) the SDK tagging followup *content* messages with `origin` (not just the `result`), or (b) a retractable preview channel in the ACP protocol. Neither exists today.

2. **A dedicated session-update variant / `_meta` marker for background-task output.** Followup and lifecycle updates currently piggyback on `agent_message_chunk` (the followup's `usage_update` already carries `_claude/origin`). A richer scheme — tagging every followup chunk with `_meta` or a dedicated `task_*` session-update so clients can render background output distinctly — is additive and backward-compatible, but only produces visible effect once an ACP client consumes it. Left for a follow-up coordinated with client-side rendering rather than shipped speculatively here.


