### PR TITLE
Emit heartbeats for long-running tool calls

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -335,6 +335,24 @@ function stopToolCallHeartbeat(sessionId: string, toolCallId: string): void {
   toolCallHeartbeatTimers.delete(key);
 }
 
+/**
+ * Clear every heartbeat belonging to a session. A heartbeat is normally
+ * stopped when its tool_result arrives (see `stopToolCallHeartbeat`), but a
+ * tool_use can end without one — the turn is cancelled, the stream aborts, or
+ * the session is torn down. Without this sweep the `setInterval` and its Map
+ * entry would leak for the lifetime of the process. Exported for the prompt
+ * turn-end, cancel, and teardown paths (and the regression test).
+ */
+export function clearToolCallHeartbeatsForSession(sessionId: string): void {
+  const prefix = `${sessionId}:`;
+  for (const [key, timer] of toolCallHeartbeatTimers) {
+    if (key.startsWith(prefix)) {
+      clearInterval(timer);
+      toolCallHeartbeatTimers.delete(key);
+    }
+  }
+}
+
 export async function claudeCliPath(): Promise<string> {
   if (process.env.CLAUDE_CODE_EXECUTABLE) {
     return process.env.CLAUDE_CODE_EXECUTABLE;
@@ -1404,6 +1422,10 @@ export class ClaudeAcpAgent implements Agent {
     } finally {
       if (!handedOff) {
         session.promptRunning = false;
+        // The turn is over; no further tool_results will arrive for its tools.
+        // Clear any heartbeat still running so a tool_use that never resolved
+        // (errored or partial stream) doesn't leak its interval.
+        clearToolCallHeartbeatsForSession(params.sessionId);
         if (errored) {
           // The query stream was just drained — handing pending prompts off
           // onto it would let them race with the recovery. Cancel them so
@@ -1435,6 +1457,10 @@ export class ClaudeAcpAgent implements Agent {
       return;
     }
     session.cancelled = true;
+    // Cancellation aborts in-flight tools; their tool_results may never land,
+    // so the per-tool heartbeats must be swept here rather than waiting on a
+    // result that won't arrive.
+    clearToolCallHeartbeatsForSession(params.sessionId);
     for (const [, pending] of session.pendingMessages) {
       pending.resolve(true);
     }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -281,6 +281,60 @@ export type ToolUseCache = {
   };
 };
 
+const TOOL_CALL_HEARTBEAT_INTERVAL_MS = 60_000;
+const toolCallHeartbeatTimers = new Map<string, ReturnType<typeof setInterval>>();
+
+function toolCallHeartbeatKey(sessionId: string, toolCallId: string): string {
+  return `${sessionId}:${toolCallId}`;
+}
+
+function startToolCallHeartbeat(
+  sessionId: string,
+  toolCallId: string,
+  toolName: string,
+  client: AgentSideConnection,
+  logger: Logger,
+  parentToolUseId?: string | null,
+): void {
+  const key = toolCallHeartbeatKey(sessionId, toolCallId);
+  if (toolCallHeartbeatTimers.has(key)) {
+    return;
+  }
+
+  const timer = setInterval(() => {
+    void client
+      .sessionUpdate({
+        sessionId,
+        update: {
+          _meta: {
+            claudeCode: {
+              toolName,
+              ...(parentToolUseId ? { parentToolUseId } : {}),
+            },
+          } satisfies ToolUpdateMeta,
+          toolCallId,
+          sessionUpdate: "tool_call_update",
+          status: "pending",
+        },
+      })
+      .catch((error: unknown) => {
+        logger.error("[claude-agent-acp] Failed to send tool heartbeat", error);
+      });
+  }, TOOL_CALL_HEARTBEAT_INTERVAL_MS);
+  timer.unref?.();
+  toolCallHeartbeatTimers.set(key, timer);
+}
+
+function stopToolCallHeartbeat(sessionId: string, toolCallId: string): void {
+  const key = toolCallHeartbeatKey(sessionId, toolCallId);
+  const timer = toolCallHeartbeatTimers.get(key);
+  if (!timer) {
+    return;
+  }
+  clearInterval(timer);
+  toolCallHeartbeatTimers.delete(key);
+}
+
 export async function claudeCliPath(): Promise<string> {
   if (process.env.CLAUDE_CODE_EXECUTABLE) {
     return process.env.CLAUDE_CODE_EXECUTABLE;
@@ -3067,6 +3121,14 @@ export function toAcpNotifications(
               status: "pending",
               ...toolInfoFromToolUse(chunk, supportsTerminalOutput, options?.cwd),
             };
+            startToolCallHeartbeat(
+              sessionId,
+              chunk.id,
+              chunk.name,
+              client,
+              logger,
+              options?.parentToolUseId,
+            );
           }
         }
         break;
@@ -3081,6 +3143,7 @@ export function toAcpNotifications(
       case "text_editor_code_execution_tool_result":
       case "mcp_tool_result": {
         const toolUse = toolUseCache[chunk.tool_use_id];
+        stopToolCallHeartbeat(sessionId, chunk.tool_use_id);
         if (!toolUse) {
           logger.error(
             `[claude-agent-acp] Got a tool result for tool use that wasn't tracked: ${chunk.tool_use_id}`,

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -10,7 +10,12 @@ import {
   BetaBashCodeExecutionResultBlock,
   BetaBashCodeExecutionToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
-import { toAcpNotifications, ToolUseCache, Logger } from "../acp-agent.js";
+import {
+  toAcpNotifications,
+  clearToolCallHeartbeatsForSession,
+  ToolUseCache,
+  Logger,
+} from "../acp-agent.js";
 import {
   toolUpdateFromToolResult,
   createPostToolUseHook,
@@ -27,10 +32,6 @@ import {
 describe("rawOutput in tool call updates", () => {
   const mockClient = {} as AgentSideConnection;
   const mockLogger: Logger = { log: () => {}, error: () => {} };
-
-  afterEach(() => {
-    vi.useRealTimers();
-  });
 
   it("should include rawOutput with string content for tool_result", () => {
     const toolUseCache: ToolUseCache = {
@@ -853,82 +854,6 @@ describe("Bash terminal output", () => {
   });
 
   describe("post-tool-use hook sends diff content for Edit tool", () => {
-    it("emits periodic in-progress heartbeats until the tool result arrives", async () => {
-      vi.useFakeTimers();
-      const toolUseCache: ToolUseCache = {};
-      const sessionUpdates: any[] = [];
-      const mockClientWithUpdate = {
-        sessionUpdate: async (notification: any) => {
-          sessionUpdates.push(notification);
-        },
-      } as unknown as AgentSideConnection;
-
-      const toolUseNotifications = toAcpNotifications(
-        [
-          {
-            type: "tool_use" as const,
-            id: "toolu_quiet_read",
-            name: "Read",
-            input: {
-              file_path: "/tmp/timeout_shot.jpg",
-            },
-          },
-        ],
-        "assistant",
-        "test-session",
-        toolUseCache,
-        mockClientWithUpdate,
-        mockLogger,
-      );
-
-      expect(toolUseNotifications).toHaveLength(1);
-      expect(toolUseNotifications[0].update).toMatchObject({
-        sessionUpdate: "tool_call",
-        toolCallId: "toolu_quiet_read",
-        status: "pending",
-      });
-
-      await vi.advanceTimersByTimeAsync(60_000);
-
-      expect(sessionUpdates).toHaveLength(1);
-      expect(sessionUpdates[0].update).toMatchObject({
-        sessionUpdate: "tool_call_update",
-        toolCallId: "toolu_quiet_read",
-        status: "pending",
-        _meta: {
-          claudeCode: {
-            toolName: "Read",
-          },
-        },
-      });
-
-      const resultNotifications = toAcpNotifications(
-        [
-          {
-            type: "tool_result" as const,
-            tool_use_id: "toolu_quiet_read",
-            content: "done",
-            is_error: false,
-          },
-        ],
-        "assistant",
-        "test-session",
-        toolUseCache,
-        mockClientWithUpdate,
-        mockLogger,
-      );
-
-      expect(resultNotifications).toHaveLength(1);
-      expect(resultNotifications[0].update).toMatchObject({
-        sessionUpdate: "tool_call_update",
-        toolCallId: "toolu_quiet_read",
-        status: "completed",
-      });
-
-      await vi.advanceTimersByTimeAsync(60_000);
-      expect(sessionUpdates).toHaveLength(1);
-    });
-
     it("should include content and locations from structuredPatch in hook update", async () => {
       const toolUseCache: ToolUseCache = {};
 
@@ -1480,6 +1405,132 @@ describe("Bash terminal output", () => {
       expect(hookMeta.terminal_output).toBeUndefined();
       expect(hookMeta.terminal_exit).toBeUndefined();
     });
+  });
+});
+
+describe("tool call heartbeat", () => {
+  const mockLogger: Logger = { log: () => {}, error: () => {} };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("emits periodic in-progress heartbeats until the tool result arrives", async () => {
+    vi.useFakeTimers();
+    const toolUseCache: ToolUseCache = {};
+    const sessionUpdates: any[] = [];
+    const mockClientWithUpdate = {
+      sessionUpdate: async (notification: any) => {
+        sessionUpdates.push(notification);
+      },
+    } as unknown as AgentSideConnection;
+
+    const toolUseNotifications = toAcpNotifications(
+      [
+        {
+          type: "tool_use" as const,
+          id: "toolu_quiet_read",
+          name: "Read",
+          input: {
+            file_path: "/tmp/timeout_shot.jpg",
+          },
+        },
+      ],
+      "assistant",
+      "test-session",
+      toolUseCache,
+      mockClientWithUpdate,
+      mockLogger,
+    );
+
+    expect(toolUseNotifications).toHaveLength(1);
+    expect(toolUseNotifications[0].update).toMatchObject({
+      sessionUpdate: "tool_call",
+      toolCallId: "toolu_quiet_read",
+      status: "pending",
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(sessionUpdates).toHaveLength(1);
+    expect(sessionUpdates[0].update).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "toolu_quiet_read",
+      status: "pending",
+      _meta: {
+        claudeCode: {
+          toolName: "Read",
+        },
+      },
+    });
+
+    const resultNotifications = toAcpNotifications(
+      [
+        {
+          type: "tool_result" as const,
+          tool_use_id: "toolu_quiet_read",
+          content: "done",
+          is_error: false,
+        },
+      ],
+      "assistant",
+      "test-session",
+      toolUseCache,
+      mockClientWithUpdate,
+      mockLogger,
+    );
+
+    expect(resultNotifications).toHaveLength(1);
+    expect(resultNotifications[0].update).toMatchObject({
+      sessionUpdate: "tool_call_update",
+      toolCallId: "toolu_quiet_read",
+      status: "completed",
+    });
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sessionUpdates).toHaveLength(1);
+  });
+
+  it("stops heartbeating when the session is cleared without a tool result", async () => {
+    // Leak regression: a tool_use can end without a tool_result (turn
+    // cancelled, stream aborted, session torn down). The prompt/cancel/
+    // teardown paths call clearToolCallHeartbeatsForSession; verify that sweep
+    // actually stops the interval rather than leaving it running forever.
+    vi.useFakeTimers();
+    const toolUseCache: ToolUseCache = {};
+    const sessionUpdates: any[] = [];
+    const mockClientWithUpdate = {
+      sessionUpdate: async (notification: any) => {
+        sessionUpdates.push(notification);
+      },
+    } as unknown as AgentSideConnection;
+
+    toAcpNotifications(
+      [
+        {
+          type: "tool_use" as const,
+          id: "toolu_abandoned",
+          name: "Read",
+          input: { file_path: "/tmp/abandoned.txt" },
+        },
+      ],
+      "assistant",
+      "leak-session",
+      toolUseCache,
+      mockClientWithUpdate,
+      mockLogger,
+    );
+
+    // One beat lands while the tool is still pending.
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(sessionUpdates).toHaveLength(1);
+
+    // No tool_result arrives — the turn ends and the session is swept.
+    clearToolCallHeartbeatsForSession("leak-session");
+
+    // Advancing well past several intervals must produce no further beats.
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(sessionUpdates).toHaveLength(1);
   });
 });
 

--- a/src/tests/tools.test.ts
+++ b/src/tests/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import { AgentSideConnection, ClientCapabilities } from "@agentclientprotocol/sdk";
 import { ImageBlockParam, ToolResultBlockParam } from "@anthropic-ai/sdk/resources";
 import {
@@ -27,6 +27,10 @@ import {
 describe("rawOutput in tool call updates", () => {
   const mockClient = {} as AgentSideConnection;
   const mockLogger: Logger = { log: () => {}, error: () => {} };
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it("should include rawOutput with string content for tool_result", () => {
     const toolUseCache: ToolUseCache = {
@@ -849,6 +853,82 @@ describe("Bash terminal output", () => {
   });
 
   describe("post-tool-use hook sends diff content for Edit tool", () => {
+    it("emits periodic in-progress heartbeats until the tool result arrives", async () => {
+      vi.useFakeTimers();
+      const toolUseCache: ToolUseCache = {};
+      const sessionUpdates: any[] = [];
+      const mockClientWithUpdate = {
+        sessionUpdate: async (notification: any) => {
+          sessionUpdates.push(notification);
+        },
+      } as unknown as AgentSideConnection;
+
+      const toolUseNotifications = toAcpNotifications(
+        [
+          {
+            type: "tool_use" as const,
+            id: "toolu_quiet_read",
+            name: "Read",
+            input: {
+              file_path: "/tmp/timeout_shot.jpg",
+            },
+          },
+        ],
+        "assistant",
+        "test-session",
+        toolUseCache,
+        mockClientWithUpdate,
+        mockLogger,
+      );
+
+      expect(toolUseNotifications).toHaveLength(1);
+      expect(toolUseNotifications[0].update).toMatchObject({
+        sessionUpdate: "tool_call",
+        toolCallId: "toolu_quiet_read",
+        status: "pending",
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+
+      expect(sessionUpdates).toHaveLength(1);
+      expect(sessionUpdates[0].update).toMatchObject({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "toolu_quiet_read",
+        status: "pending",
+        _meta: {
+          claudeCode: {
+            toolName: "Read",
+          },
+        },
+      });
+
+      const resultNotifications = toAcpNotifications(
+        [
+          {
+            type: "tool_result" as const,
+            tool_use_id: "toolu_quiet_read",
+            content: "done",
+            is_error: false,
+          },
+        ],
+        "assistant",
+        "test-session",
+        toolUseCache,
+        mockClientWithUpdate,
+        mockLogger,
+      );
+
+      expect(resultNotifications).toHaveLength(1);
+      expect(resultNotifications[0].update).toMatchObject({
+        sessionUpdate: "tool_call_update",
+        toolCallId: "toolu_quiet_read",
+        status: "completed",
+      });
+
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(sessionUpdates).toHaveLength(1);
+    });
+
     it("should include content and locations from structuredPatch in hook update", async () => {
       const toolUseCache: ToolUseCache = {};
 


### PR DESCRIPTION
## Why
ACP clients commonly use tool lifecycle updates as the only observable liveness signal for an in-flight tool call. Between the initial `tool_call` and the terminal `tool_result` update, the bridge emits nothing — so a client cannot distinguish a healthy quiet tool from a wedged bridge or a dropped/delayed terminal update. In practice this trips client-side stall watchdogs and cancels a turn even though Claude is still working.

This is fundamentally a transport-liveness gap, not a claim that any specific tool is slow. The heartbeat keeps the existing tool row alive without adding user-visible output or fake progress text, so a quiet-but-healthy tool is no longer indistinguishable from a hang.

## Summary
- Start a lightweight per-tool heartbeat after emitting the initial ACP `tool_call`.
- Send periodic `tool_call_update` notifications (every 60s) while a tool remains pending.
- Stop the heartbeat when the matching `tool_result` arrives.
- **Clear leaked heartbeats when a tool ends without a result.** A `tool_use` can terminate with no `tool_result` — turn cancelled, stream aborted, or session torn down. `clearToolCallHeartbeatsForSession` sweeps a session's timers, and is called from the prompt turn-end, `cancel()`, and (via `cancel`) teardown paths so an unresolved tool can't leak its interval for the lifetime of the process.

## Tests
- Heartbeat fires every 60s while pending and stops once the `tool_result` lands.
- Leak regression: after `clearToolCallHeartbeatsForSession`, advancing timers past several intervals produces no further beats.
- Heartbeat tests live in their own `describe` block with isolated fake-timer cleanup.

## Verification
- `npm test -- --run` (301 passed)
- `npm run build`
- `npm run check`
