### PR TITLE
fix: preserve ANTHROPIC_CUSTOM_MODEL_OPTION when availableModels is set

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -3195,6 +3195,21 @@ function applyAvailableModelsAllowlist(sdkModels: ModelInfo[], allowlist: string
     seen.add(trimmed);
   }
 
+  // The custom model option (ANTHROPIC_CUSTOM_MODEL_OPTION) is exempt from the
+  // allowlist, the same way Default is. Per the model-config docs it adds an
+  // entry "without replacing the built-in aliases" and "appears at the bottom of
+  // the /model picker", so we append it last and skip the allowlist filter; this
+  // keeps a slim alias allowlist from hiding the custom model row.
+  // https://code.claude.com/docs/en/model-config#add-a-custom-model-option
+  const customModelOption = process.env.ANTHROPIC_CUSTOM_MODEL_OPTION?.trim();
+  if (customModelOption && !seen.has(customModelOption)) {
+    const customModel = sdkModels.find((m) => m.value === customModelOption);
+    if (customModel) {
+      result.push(customModel);
+      seen.add(customModel.value);
+    }
+  }
+
   return result;
 }
 

--- a/src/tests/acp-agent-settings.test.ts
+++ b/src/tests/acp-agent-settings.test.ts
@@ -700,6 +700,118 @@ describe("ClaudeAcpAgent settings", () => {
       expect(byValue["claude-opus-4-6[1m]"].name).toBe("claude-opus-4-6[1m]");
       expect(byValue["claude-opus-4-6"].name).toBe("claude-opus-4-6");
     });
+
+    it("preserves ANTHROPIC_CUSTOM_MODEL_OPTION even when absent from the allowlist", async () => {
+      // Per the model-config docs, ANTHROPIC_CUSTOM_MODEL_OPTION adds an entry
+      // "without replacing the built-in aliases" and "appears at the bottom of
+      // the /model picker", so it is exempt from the availableModels allowlist
+      // (the same way the Default option is "not affected by availableModels").
+      // ACP must match: a slim alias allowlist must not hide the custom model
+      // row, and it appears last, after the allowlisted entries.
+      // https://code.claude.com/docs/en/model-config#add-a-custom-model-option
+      const originalEnv = process.env.ANTHROPIC_CUSTOM_MODEL_OPTION;
+      process.env.ANTHROPIC_CUSTOM_MODEL_OPTION = "claude-opus-4-8[1m]";
+      try {
+        await fs.promises.writeFile(
+          path.join(tempDir, "settings.json"),
+          JSON.stringify({
+            availableModels: ["sonnet", "opus", "haiku"],
+          }),
+        );
+
+        const projectDir = path.join(tempDir, "project");
+        await fs.promises.mkdir(projectDir, { recursive: true });
+
+        mockQueryWithModels([
+          { value: "default", displayName: "Default", description: "Default model" },
+          { value: "sonnet", displayName: "Sonnet", description: "Claude Sonnet 4.6" },
+          { value: "opus", displayName: "Opus", description: "Claude Opus 4.6" },
+          { value: "haiku", displayName: "Haiku", description: "Claude Haiku 4.5" },
+          {
+            value: "claude-opus-4-8[1m]",
+            displayName: "Opus 4.8",
+            description: "Claude Opus 4.8",
+          },
+        ]);
+
+        const { ClaudeAcpAgent } = await import("../acp-agent.js");
+        const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
+
+        const response = await (agent as any).createSession({
+          cwd: projectDir,
+          mcpServers: [],
+          _meta: { disableBuiltInTools: true },
+        });
+
+        const modelOption = response.configOptions.find((o: any) => o.id === "model");
+        expect(modelOption.options.map((o: any) => o.value)).toEqual([
+          "default",
+          "sonnet",
+          "opus",
+          "haiku",
+          "claude-opus-4-8[1m]",
+        ]);
+        const custom = modelOption.options.find((o: any) => o.value === "claude-opus-4-8[1m]");
+        expect(custom.name).toBe("Opus 4.8");
+        expect(custom.description).toBe("Claude Opus 4.8");
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.ANTHROPIC_CUSTOM_MODEL_OPTION;
+        } else {
+          process.env.ANTHROPIC_CUSTOM_MODEL_OPTION = originalEnv;
+        }
+      }
+    });
+
+    it("does not duplicate the custom model option when also in the allowlist", async () => {
+      // If the user lists the custom model's exact ID in availableModels AND it
+      // is set as ANTHROPIC_CUSTOM_MODEL_OPTION, it must appear exactly once.
+      const originalEnv = process.env.ANTHROPIC_CUSTOM_MODEL_OPTION;
+      process.env.ANTHROPIC_CUSTOM_MODEL_OPTION = "claude-opus-4-8[1m]";
+      try {
+        await fs.promises.writeFile(
+          path.join(tempDir, "settings.json"),
+          JSON.stringify({
+            availableModels: ["sonnet", "claude-opus-4-8[1m]"],
+          }),
+        );
+
+        const projectDir = path.join(tempDir, "project");
+        await fs.promises.mkdir(projectDir, { recursive: true });
+
+        mockQueryWithModels([
+          { value: "default", displayName: "Default", description: "Default model" },
+          { value: "sonnet", displayName: "Sonnet", description: "Claude Sonnet 4.6" },
+          {
+            value: "claude-opus-4-8[1m]",
+            displayName: "Opus 4.8",
+            description: "Claude Opus 4.8",
+          },
+        ]);
+
+        const { ClaudeAcpAgent } = await import("../acp-agent.js");
+        const agent: ClaudeAcpAgentType = new ClaudeAcpAgent(createMockClient());
+
+        const response = await (agent as any).createSession({
+          cwd: projectDir,
+          mcpServers: [],
+          _meta: { disableBuiltInTools: true },
+        });
+
+        const modelOption = response.configOptions.find((o: any) => o.id === "model");
+        expect(modelOption.options.map((o: any) => o.value)).toEqual([
+          "default",
+          "sonnet",
+          "claude-opus-4-8[1m]",
+        ]);
+      } finally {
+        if (originalEnv === undefined) {
+          delete process.env.ANTHROPIC_CUSTOM_MODEL_OPTION;
+        } else {
+          process.env.ANTHROPIC_CUSTOM_MODEL_OPTION = originalEnv;
+        }
+      }
+    });
   });
 
   it("resolves model aliases like opus[1m] to the correct model", async () => {


### PR DESCRIPTION
## Summary

When `availableModels` is set to a slim list (e.g. `["sonnet","opus","haiku"]`), the model from `ANTHROPIC_CUSTOM_MODEL_OPTION` was dropped from `session/new`'s model picker. Claude Code's CLI keeps it; ACP hid it.

Per the [model-config docs](https://code.claude.com/docs/en/model-config#add-a-custom-model-option), `ANTHROPIC_CUSTOM_MODEL_OPTION` adds a custom entry "without replacing the built-in aliases" and "appears at the bottom of the `/model` picker" — i.e. it's additive, not subject to the alias allowlist.

Observed under:
* `availableModels: ["sonnet","opus","haiku"]`
* `ANTHROPIC_DEFAULT_OPUS_MODEL=claude-opus-4-6[1m]`
* `ANTHROPIC_CUSTOM_MODEL_OPTION=claude-opus-4-8[1m]`

| | Default | Sonnet | Opus | Haiku | Opus 4.8 |
|---|---|---|---|---|---|
| CLI picker | ✅ | ✅ | ✅ | ✅ | ✅ (bottom) |
| ACP (before) | ✅ | ✅ | ✅ | ✅ | ❌ |
| ACP (after) | ✅ | ✅ | ✅ | ✅ | ✅ (bottom) |

### Root cause

The SDK returns the custom option as an ordinary entry in `initializationResult.models` with no flag distinguishing it (`ModelInfo` has no `custom`/`isCustom` field). `applyAvailableModelsAllowlist` treats `availableModels` as a strict allowlist: keep `default`, then keep only SDK models matching an allowlist entry. The custom value (`claude-opus-4-8[1m]`) matches no alias, so it's filtered out — diverging from the CLI's additive treatment.

### Fix

After the allowlist loop, append the model named by `ANTHROPIC_CUSTOM_MODEL_OPTION` if the SDK surfaced it and it isn't already present. It's placed last, matching the documented "bottom of the picker" position, and exempted from the allowlist the same way we already exempt `default` (the docs note the Default option is likewise "not affected by `availableModels`").

The entry is preserved in the `ModelInfo[]` (`allowedModels` / session `modelInfos`), not just the trimmed picker list, so its capability flags (`supportedEffortLevels`, `supportsAutoMode`) flow to mode gating and the effort dropdown when the custom model is selected.

Only the allowlist path needs this — when `availableModels` is absent, ACP uses the full SDK list, which already contains the custom option.

## Test Plan

`src/tests/acp-agent-settings.test.ts` (TDD):
- Custom option preserved at the end of the list when absent from a slim allowlist, with its name/description intact.
- No duplication when the custom option's exact ID is *also* in `availableModels`.

No behavior change when `ANTHROPIC_CUSTOM_MODEL_OPTION` is unset or when `availableModels` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)