### PR TITLE
fix: Forward option details in elicitation meta

### DIFF
--- a/src/elicitation.ts
+++ b/src/elicitation.ts
@@ -126,6 +126,34 @@ function questionCustomFieldKey(index: number): string {
 }
 
 /**
+ * `_meta` key under which a bridged enum option carries its structured
+ * `description`/`preview`, since ACP's `EnumOption` has no field for either.
+ * Namespaced like the agent's other `_meta` extensions (`_claude/...`).
+ */
+const OPTION_META_KEY = "_claude/askUserQuestionOption";
+
+/** A single option as supplied by the AskUserQuestion tool. */
+type AskUserQuestionOption = AskUserQuestion["options"][number];
+
+/**
+ * Build the `_meta` payload that carries an option's structured `description`
+ * and optional `preview` for clients that can render them as distinct fields.
+ * Returns `undefined` when neither is present, so we don't emit an empty `_meta`.
+ */
+function askUserQuestionOptionMeta(
+  option: AskUserQuestionOption,
+): NonNullable<EnumOption["_meta"]> | undefined {
+  const detail: { description?: string; preview?: string } = {};
+  if (option.description) {
+    detail.description = option.description;
+  }
+  if (option.preview) {
+    detail.preview = option.preview;
+  }
+  return Object.keys(detail).length > 0 ? { [OPTION_META_KEY]: detail } : undefined;
+}
+
+/**
  * Render the AskUserQuestion tool's questions as an ACP form elicitation.
  *
  * Fields are keyed by a short stable id (`question_<n>`) rather than the full
@@ -149,10 +177,25 @@ export function askUserQuestionsToCreateRequest(
   const properties: Record<string, ElicitationPropertySchema> = {};
 
   questions.forEach((question, index) => {
-    const options: EnumOption[] = question.options.map((option) => ({
-      const: option.label,
-      title: option.description ? `${option.label} — ${option.description}` : option.label,
-    }));
+    const options: EnumOption[] = question.options.map((option) => {
+      const enumOption: EnumOption = {
+        const: option.label,
+        // `title` stays a flattened "label — description" string so clients that
+        // only read `const`/`title` still surface the description. Clients that
+        // understand the `_meta` below should prefer its structured fields (and
+        // treat `const` as the clean label) rather than parsing this title.
+        title: option.description ? `${option.label} — ${option.description}` : option.label,
+      };
+      // The SDK option carries a `description` (secondary text) and an optional
+      // `preview` (mockups, code snippets, comparisons shown on focus). Neither
+      // has a structural slot in `EnumOption`, so forward them under ACP's
+      // reserved `_meta` extension point for clients that can render them.
+      const meta = askUserQuestionOptionMeta(option);
+      if (meta) {
+        enumOption._meta = meta;
+      }
+      return enumOption;
+    });
 
     // For a single question the prompt is carried by `message`, so we don't
     // repeat it in the field description. With multiple questions each field

--- a/src/tests/elicitation.test.ts
+++ b/src/tests/elicitation.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import type { CreateElicitationRequest, CreateElicitationResponse } from "@agentclientprotocol/sdk";
+import type {
+  CreateElicitationRequest,
+  CreateElicitationResponse,
+  EnumOption,
+} from "@agentclientprotocol/sdk";
 import type { ElicitationRequest } from "@anthropic-ai/claude-agent-sdk";
 import {
   applyAskElicitationResponse,
@@ -19,14 +23,18 @@ const SESSION_ID = "session-1";
  */
 function mkQuestion(
   question: string,
-  options: Array<{ label: string; description?: string }>,
+  options: Array<{ label: string; description?: string; preview?: string }>,
   opts: { header?: string; multiSelect?: boolean } = {},
 ): AskUserQuestion {
   return {
     question,
     header: opts.header ?? "",
     multiSelect: opts.multiSelect ?? false,
-    options: options.map((o) => ({ label: o.label, description: o.description ?? "" })),
+    options: options.map((o) => ({
+      label: o.label,
+      description: o.description ?? "",
+      ...(o.preview ? { preview: o.preview } : {}),
+    })),
   } as AskUserQuestion;
 }
 
@@ -179,12 +187,60 @@ describe("askUserQuestionsToCreateRequest", () => {
       title: "Library",
       description: undefined,
       oneOf: [
-        { const: "date-fns", title: "date-fns — Lightweight" },
+        {
+          const: "date-fns",
+          title: "date-fns — Lightweight",
+          // Structured description forwarded under `_meta` so clients can render
+          // it as secondary text instead of parsing it out of the title.
+          _meta: { "_claude/askUserQuestionOption": { description: "Lightweight" } },
+        },
+        // No description → no `_meta` emitted.
         { const: "luxon", title: "luxon" },
       ],
     });
     // The full question text is not used as a property key.
     expect(schema.properties?.["Which library?"]).toBeUndefined();
+  });
+
+  it("forwards option description and preview under _meta for rich clients", () => {
+    const questions = [
+      mkQuestion("Which layout?", [
+        {
+          label: "Grid",
+          description: "Cards in a responsive grid",
+          preview: "```\n[ ] [ ] [ ]\n[ ] [ ] [ ]\n```",
+        },
+        { label: "List", description: "Stacked rows" },
+        { label: "Plain" },
+      ]),
+    ];
+
+    const schema = (
+      askUserQuestionsToCreateRequest(questions, SESSION_ID, undefined) as Extract<
+        CreateElicitationRequest,
+        { mode: "form" }
+      >
+    ).requestedSchema;
+    const oneOf = (schema.properties?.["question_0"] as { oneOf: EnumOption[] }).oneOf;
+
+    // Both description and preview travel structurally; the title still flattens
+    // the description for clients that only read const/title.
+    expect(oneOf[0]).toEqual({
+      const: "Grid",
+      title: "Grid — Cards in a responsive grid",
+      _meta: {
+        "_claude/askUserQuestionOption": {
+          description: "Cards in a responsive grid",
+          preview: "```\n[ ] [ ] [ ]\n[ ] [ ] [ ]\n```",
+        },
+      },
+    });
+    // Description only → preview omitted from _meta.
+    expect(oneOf[1]._meta).toEqual({
+      "_claude/askUserQuestionOption": { description: "Stacked rows" },
+    });
+    // Neither → no _meta at all.
+    expect(oneOf[2]._meta).toBeUndefined();
   });
 
   it("includes a per-question optional free-text custom-answer field", () => {


### PR DESCRIPTION
Closes #764
