### PR TITLE
fix: Better handle out of turn events

### DIFF
--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -196,6 +196,15 @@ type Session = {
   /** The turn whose messages the consumer is currently attributing output to
    *  (the head of `turnQueue` once its user message has been echoed). */
   activeTurn?: Turn | null;
+  /** Count of result messages the consumer should treat as orphans and skip
+   *  (not promote/attribute to the current head). When cancel() settles+removes
+   *  a queued turn, that turn's user message was already pushed to the SDK, so
+   *  the SDK still runs it and emits a result with no uuid we can match. Because
+   *  the SDK processes input FIFO, those orphan results arrive (in submission
+   *  order) before the next live turn's, so skipping exactly this many leaves
+   *  the genuine head untouched. Reset to 0 on every activation as a backstop
+   *  against an SDK that drops queued input on interrupt (no orphan emitted). */
+  pendingOrphanResults?: number;
   /** The long-lived consumer task. Lazily started on the first `prompt()` and
    *  kept alive for the session so between-turn/background messages are still
    *  drained and forwarded. */
@@ -978,10 +987,16 @@ export class ClaudeAcpAgent implements Agent {
 
     /** Promote a queued turn to active: it becomes the one output is attributed
      *  to, and its scratch starts fresh. Clears the cancelled flag so a turn
-     *  enqueued after a prior cancel isn't treated as cancelled. */
+     *  enqueued after a prior cancel isn't treated as cancelled. Also clears any
+     *  leftover orphan-skip count: since the SDK echoes/runs input FIFO, every
+     *  orphan from a prior cancel has already arrived by the time a live turn
+     *  activates, so a non-zero remainder means the SDK dropped a queued turn on
+     *  interrupt (no orphan emitted) — drop the stale count so a later echo-less
+     *  result isn't wrongly skipped. */
     const activateTurn = (turn: Turn) => {
       session.activeTurn = turn;
       session.cancelled = false;
+      session.pendingOrphanResults = 0;
       resetTurnScratch();
     };
 
@@ -993,20 +1008,26 @@ export class ClaudeAcpAgent implements Agent {
      *  are the generated summary and a `<local-command-stdout>` replay — neither
      *  carries the prompt's uuid). Promoting the head settles those.
      *
-     *  Gated on `!session.cancelled`: a result that arrives while a cancel is
-     *  pending is an orphan — e.g. the SDK still ran a turn that cancel() already
-     *  resolved and removed (its user message was pushed before the cancel), so
-     *  the head is now an unrelated later prompt. Promoting it would misattribute
-     *  the orphan's stop reason/usage. In normal (non-cancelled) operation the
-     *  head IS the turn the SDK is running, so promoting it is correct. */
+     *  But an echo-less result can also be an ORPHAN: cancel() settles+removes a
+     *  queued turn whose user message was already pushed, so the SDK still runs
+     *  it and emits a result with no uuid to match. Promoting the head for an
+     *  orphan would misattribute its stop reason/usage to an unrelated later
+     *  prompt. `session.pendingOrphanResults` counts exactly how many such
+     *  orphans are still expected (FIFO, they arrive before any live turn's
+     *  result), so we skip those and only promote once the count is drained. */
     const ensureActiveTurn = () => {
-      if (session.activeTurn || session.cancelled) {
+      if (session.activeTurn) {
         return;
       }
       const head = (session.turnQueue ?? []).find((t) => !t.settled);
-      if (head) {
-        activateTurn(head);
+      if (!head) {
+        return;
       }
+      if ((session.pendingOrphanResults ?? 0) > 0) {
+        session.pendingOrphanResults!--;
+        return;
+      }
+      activateTurn(head);
     };
 
     /** Settle the active turn's deferred exactly once, disarm the force-cancel
@@ -1946,12 +1967,19 @@ export class ClaudeAcpAgent implements Agent {
     // by the consumer when it observes the interrupt's trailing idle (or via the
     // backstop below). Mirrors the old pendingMessages cancellation.
     if (session.turnQueue) {
+      let orphaned = 0;
       for (const turn of session.turnQueue) {
         if (turn !== session.activeTurn && !turn.settled) {
           turn.settled = true;
           turn.resolve({ stopReason: "cancelled" });
+          orphaned++;
         }
       }
+      // Each removed queued turn's user message was already pushed to the SDK,
+      // which processes input FIFO and will still emit a result for it with no
+      // uuid to match. Count those so the consumer skips them (see
+      // ensureActiveTurn) rather than misattributing them to the head.
+      session.pendingOrphanResults = (session.pendingOrphanResults ?? 0) + orphaned;
       session.turnQueue = session.turnQueue.filter(
         (turn) => turn === session.activeTurn && !turn.settled,
       );

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1976,15 +1976,19 @@ export class ClaudeAcpAgent implements Agent {
     await session.query.interrupt();
   }
 
-  /** Mark a session's SDK query stream as permanently ended and release the
-   *  resources tied to it: drop the consumer handle, dispose the settings
-   *  watchers, and end the input stream. The query iterator is not revivable, so
+  /** Mark a session's SDK query stream as permanently ended and release every
+   *  resource tied to it: drop the consumer handle, dispose the settings
+   *  watchers, end the input stream, abort the SDK abort signal, and close the
+   *  query (terminating the subprocess). The query iterator is not revivable, so
    *  `prompt()`/`cancel()` consult `queryClosed` and fail/short-circuit instead
    *  of acting on a dead stream. Idempotent (guarded by `queryClosed`), so the
    *  consumer's done/error paths and a later `teardownSession` can all call it
-   *  without double-disposing. Does NOT remove the session from the map — that
-   *  is `teardownSession`'s job — so prompt() can still answer with a clear
-   *  "session ended" error after an unexpected stream close. */
+   *  without double-releasing. Does NOT remove the session from the map — that is
+   *  `teardownSession`'s job — so prompt() can still answer with a clear "session
+   *  ended" error after an unexpected stream close. The leftover session object
+   *  is a lightweight husk (its heavy resources are released here) and is evicted
+   *  on the next closeSession/deleteSession or when the connection's `dispose()`
+   *  runs. */
   private closeQueryStream(session: Session): void {
     if (session.queryClosed) {
       return;
@@ -1993,6 +1997,8 @@ export class ClaudeAcpAgent implements Agent {
     session.consumer = undefined;
     session.settingsManager.dispose();
     session.input.end();
+    session.abortController.abort();
+    session.query.close();
   }
 
   /** Cleanly tear down a session: cancel in-flight work, release stream
@@ -2004,20 +2010,18 @@ export class ClaudeAcpAgent implements Agent {
     }
     await this.cancel({ sessionId });
     // cancel() arms the force-cancel floor and interrupts gracefully, but a
-    // wedged consumer only wakes when `cancelController` aborts — closing the
-    // query/abortController below doesn't touch it. Since we're tearing the
-    // session down anyway, wake the consumer now so the in-flight prompt()
-    // resolves immediately instead of after the floor, and clear the timer so it
-    // can't outlive the deleted session (it isn't unref'd and would otherwise
-    // keep the event loop alive until it fires).
+    // wedged consumer only wakes when `cancelController` aborts — closeQueryStream
+    // below doesn't touch it. Since we're tearing the session down anyway, wake
+    // the consumer now so the in-flight prompt() resolves immediately instead of
+    // after the floor, and clear the timer so it can't outlive the deleted
+    // session (it isn't unref'd and would otherwise keep the event loop alive
+    // until it fires).
     if (session.forceCancelTimer) {
       clearTimeout(session.forceCancelTimer);
       session.forceCancelTimer = undefined;
     }
     session.cancelController?.abort();
     this.closeQueryStream(session);
-    session.abortController.abort();
-    session.query.close();
     delete this.sessions[sessionId];
   }
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -1415,6 +1415,7 @@ export class ClaudeAcpAgent implements Agent {
                 });
               }
               stopReason = "refusal";
+              settleActive({ stopReason: "refusal", usage: sessionUsage(session) });
               break;
             }
 
@@ -1494,6 +1495,16 @@ export class ClaudeAcpAgent implements Agent {
               default:
                 unreachable(message, this.logger);
                 break;
+            }
+            // Settle the user turn at its terminal result so the client unlocks
+            // as soon as the answer is done, rather than waiting for the SDK's
+            // trailing `idle` (which can lag while background work runs — issue
+            // #773). The consumer keeps draining afterward (absorbing idle and
+            // forwarding any background output). is_error/auth already settled
+            // via failActive; cancellation is left to the idle/abort path.
+            // settleActive is idempotent, so a duplicate idle is a no-op.
+            if (!isTaskNotification && !session.cancelled) {
+              settleActive({ stopReason, usage: sessionUsage(session) });
             }
             break;
           }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -985,21 +985,26 @@ export class ClaudeAcpAgent implements Agent {
       resetTurnScratch();
     };
 
-    /** Ensure there is an active turn before a result that carries no echo
-     *  (local-only commands) by promoting the queue head. Only local-only
-     *  commands legitimately return a result without a user-message echo to
-     *  activate them; a normal turn is always activated by its echo before its
-     *  result. So if the head is NOT a local-only command, leave activeTurn
-     *  unset: such a result is an orphan (e.g. the SDK still ran a queued turn
-     *  that cancel() already resolved, since its user message was pushed before
-     *  the cancel) and promoting the head would misattribute the orphan's stop
-     *  reason and usage to an unrelated queued prompt. */
+    /** Ensure there is an active turn before a user-turn result that carries no
+     *  echo to activate it, by promoting the queue head. Most turns are
+     *  activated by their replayed user message before their result, but some
+     *  legitimately produce a result with no matching echo: local-only commands
+     *  (e.g. `/context`) and compaction (`/compact`, whose only user messages
+     *  are the generated summary and a `<local-command-stdout>` replay — neither
+     *  carries the prompt's uuid). Promoting the head settles those.
+     *
+     *  Gated on `!session.cancelled`: a result that arrives while a cancel is
+     *  pending is an orphan — e.g. the SDK still ran a turn that cancel() already
+     *  resolved and removed (its user message was pushed before the cancel), so
+     *  the head is now an unrelated later prompt. Promoting it would misattribute
+     *  the orphan's stop reason/usage. In normal (non-cancelled) operation the
+     *  head IS the turn the SDK is running, so promoting it is correct. */
     const ensureActiveTurn = () => {
-      if (session.activeTurn) {
+      if (session.activeTurn || session.cancelled) {
         return;
       }
       const head = (session.turnQueue ?? []).find((t) => !t.settled);
-      if (head?.isLocalOnlyCommand) {
+      if (head) {
         activateTurn(head);
       }
     };
@@ -1096,12 +1101,12 @@ export class ClaudeAcpAgent implements Agent {
         const { value: message, done } = raced.result as IteratorResult<SDKMessage, void>;
 
         if (done || !message) {
-          // The stream ended. The query iterator can't be revived, so close the
-          // session's stream (marks queryClosed, drops the consumer handle, and
-          // releases the dead subprocess/settings resources) — a later prompt()
-          // then rejects up front rather than restarting a consumer on the
-          // exhausted stream.
-          this.closeQueryStream(session);
+          // The stream ended. Settle the in-flight turns FIRST, then release the
+          // stream resources — same order as the error paths (failAllTurns before
+          // closeQueryStream). Settling is the user-facing contract; resource
+          // release is best-effort cleanup, so a throw there must not pre-empt a
+          // turn's real outcome.
+          //
           // Settle the turn that was in flight so its prompt() doesn't hang:
           // cancelled if a cancel is pending, otherwise the accumulated outcome.
           settleActive(
@@ -1121,6 +1126,11 @@ export class ClaudeAcpAgent implements Agent {
             }
           }
           session.turnQueue = [];
+          // The query iterator can't be revived, so close the session's stream
+          // (marks queryClosed, drops the consumer handle, releases the dead
+          // subprocess/settings resources) — a later prompt() then rejects up
+          // front rather than restarting a consumer on the exhausted stream.
+          this.closeQueryStream(session);
           return;
         }
 
@@ -1976,14 +1986,20 @@ export class ClaudeAcpAgent implements Agent {
     await session.query.interrupt();
   }
 
-  /** Mark a session's SDK query stream as permanently ended and release every
-   *  resource tied to it: drop the consumer handle, dispose the settings
-   *  watchers, end the input stream, abort the SDK abort signal, and close the
-   *  query (terminating the subprocess). The query iterator is not revivable, so
-   *  `prompt()`/`cancel()` consult `queryClosed` and fail/short-circuit instead
-   *  of acting on a dead stream. Idempotent (guarded by `queryClosed`), so the
-   *  consumer's done/error paths and a later `teardownSession` can all call it
-   *  without double-releasing. Does NOT remove the session from the map — that is
+  /** Mark a session's SDK query stream as permanently ended and release the
+   *  resources tied to it: drop the consumer handle, dispose the settings
+   *  watchers, end the input stream, and close the query (which terminates the
+   *  subprocess). The query iterator is not revivable, so `prompt()`/`cancel()`
+   *  consult `queryClosed` and fail/short-circuit instead of acting on a dead
+   *  stream. Idempotent (guarded by `queryClosed`), so the consumer's done/error
+   *  paths and a later `teardownSession` can all call it without double-releasing.
+   *
+   *  Deliberately does NOT abort `session.abortController`: that controller may be
+   *  CLIENT-supplied (`_meta.claudeCode.options.abortController`) and reused, so
+   *  aborting it on a spontaneous stream end would cancel the client's own work
+   *  or make a sibling session born aborted. `query.close()` already terminates
+   *  the subprocess; aborting the signal belongs in `teardownSession` (explicit
+   *  destroy), not here. Also does NOT remove the session from the map — that is
    *  `teardownSession`'s job — so prompt() can still answer with a clear "session
    *  ended" error after an unexpected stream close. The leftover session object
    *  is a lightweight husk (its heavy resources are released here) and is evicted
@@ -1997,7 +2013,6 @@ export class ClaudeAcpAgent implements Agent {
     session.consumer = undefined;
     session.settingsManager.dispose();
     session.input.end();
-    session.abortController.abort();
     session.query.close();
   }
 
@@ -2022,6 +2037,11 @@ export class ClaudeAcpAgent implements Agent {
     }
     session.cancelController?.abort();
     this.closeQueryStream(session);
+    // Abort the SDK abort signal only on explicit destroy. closeQueryStream
+    // leaves it alone (it may be a client-owned controller — see its doc), but
+    // here the client has asked us to close the session, so signalling abort is
+    // appropriate; query.close() above has already torn the subprocess down.
+    session.abortController.abort();
     delete this.sessions[sessionId];
   }
 

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -2097,8 +2097,15 @@ export class ClaudeAcpAgent implements Agent {
   }
 
   async setSessionMode(params: SetSessionModeRequest): Promise<SetSessionModeResponse> {
-    if (!this.sessions[params.sessionId]) {
+    const session = this.sessions[params.sessionId];
+    if (!session) {
       throw new Error("Session not found");
+    }
+    // The SDK query stream already ended (see closeQueryStream); the session is
+    // a husk and `query.setPermissionMode` below would act on a closed query.
+    // Fail with the same clear message prompt()/cancel() give for a dead stream.
+    if (session.queryClosed) {
+      throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
 
     await this.applySessionMode(params.sessionId, params.modeId);
@@ -2112,6 +2119,13 @@ export class ClaudeAcpAgent implements Agent {
     const session = this.sessions[params.sessionId];
     if (!session) {
       throw new Error("Session not found");
+    }
+    // The SDK query stream already ended (see closeQueryStream); the session is
+    // a husk and the `query.setModel`/`setPermissionMode`/`applyFlagSettings`
+    // calls this triggers would act on a closed query. Fail with the same clear
+    // message prompt()/cancel() give for a dead stream.
+    if (session.queryClosed) {
+      throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
     if (typeof params.value !== "string") {
       throw new Error(`Invalid value for config option ${params.configId}: ${params.value}`);

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -420,6 +420,11 @@ function shouldHideClaudeAuth(): boolean {
   return process.argv.includes("--hide-claude-auth");
 }
 
+/** Returned to clients when a prompt or cancel targets a session whose SDK
+ *  query stream has already ended (ran to `done` or died). The stream is not
+ *  revivable, so the only recovery is a fresh session. */
+const SESSION_ENDED_MESSAGE = "The Claude Agent session has ended. Please start a new session.";
+
 // Bypass Permissions doesn't work if we are a root/sudo user
 const IS_ROOT = (process.geteuid?.() ?? process.getuid?.()) === 0;
 const ALLOW_BYPASS = !IS_ROOT || !!process.env.IS_SANDBOX;
@@ -856,10 +861,7 @@ export class ClaudeAcpAgent implements Agent {
     // can't be revived, so enqueueing here would hang on a deferred that never
     // settles. Fail clearly and let the client start a fresh session.
     if (session.queryClosed) {
-      throw RequestError.internalError(
-        undefined,
-        "The Claude Agent session has ended. Please start a new session.",
-      );
+      throw RequestError.internalError(undefined, SESSION_ENDED_MESSAGE);
     }
 
     const userMessage = promptToClaude(params);
@@ -1094,11 +1096,12 @@ export class ClaudeAcpAgent implements Agent {
         const { value: message, done } = raced.result as IteratorResult<SDKMessage, void>;
 
         if (done || !message) {
-          // The stream ended. The query iterator can't be revived, so mark the
-          // session closed; a later prompt() rejects up front rather than
-          // restarting a consumer on the exhausted stream (which would resolve
-          // end_turn without ever reaching the model).
-          session.queryClosed = true;
+          // The stream ended. The query iterator can't be revived, so close the
+          // session's stream (marks queryClosed, drops the consumer handle, and
+          // releases the dead subprocess/settings resources) — a later prompt()
+          // then rejects up front rather than restarting a consumer on the
+          // exhausted stream.
+          this.closeQueryStream(session);
           // Settle the turn that was in flight so its prompt() doesn't hang:
           // cancelled if a cancel is pending, otherwise the accumulated outcome.
           settleActive(
@@ -1106,30 +1109,18 @@ export class ClaudeAcpAgent implements Agent {
               ? { stopReason: "cancelled" }
               : { stopReason, usage: sessionUsage(session) },
           );
-          // Queued turns the SDK never started: a cancel turns them into
-          // "cancelled", but otherwise the stream died before they ran, so
-          // reject them rather than reporting a success (end_turn) for a prompt
-          // that produced no output.
+          // Queued turns the SDK never started never ran, so reject them rather
+          // than reporting a success (end_turn) — or a misleading "cancelled" —
+          // for a prompt that produced no output. (A cancel already settled the
+          // turns that were queued at cancel time and removed them, so anything
+          // still here was enqueued afterward and was not part of the cancel.)
           for (const queued of [...(session.turnQueue ?? [])]) {
             if (!queued.settled) {
               queued.settled = true;
-              if (session.cancelled) {
-                queued.resolve({ stopReason: "cancelled" });
-              } else {
-                queued.reject(
-                  RequestError.internalError(
-                    undefined,
-                    "The Claude Agent session ended before this prompt ran. Please start a new session.",
-                  ),
-                );
-              }
+              queued.reject(RequestError.internalError(undefined, SESSION_ENDED_MESSAGE));
             }
           }
           session.turnQueue = [];
-          // Drop the finished consumer handle. With queryClosed set, prompt()
-          // won't restart it, but clearing keeps the dead promise from being
-          // mistaken for a live consumer.
-          session.consumer = undefined;
           return;
         }
 
@@ -1677,7 +1668,16 @@ export class ClaudeAcpAgent implements Agent {
                 // must not have its accumulated usage reset by its own echo.
                 if (session.activeTurn !== queued) {
                   if (session.activeTurn) {
-                    settleActive({ stopReason: "end_turn", usage: sessionUsage(session) });
+                    // Hand off the previous turn. If a cancel is pending for it
+                    // (its trailing idle hasn't arrived yet), settle it
+                    // "cancelled" per the ACP contract rather than "end_turn" —
+                    // otherwise a cancel followed quickly by the next prompt
+                    // would report the cancelled turn as a normal completion.
+                    settleActive(
+                      session.cancelled
+                        ? { stopReason: "cancelled" }
+                        : { stopReason: "end_turn", usage: sessionUsage(session) },
+                    );
                   }
                   activateTurn(queued);
                 }
@@ -1895,6 +1895,11 @@ export class ClaudeAcpAgent implements Agent {
           message.includes("process exited with") ||
           message.includes("process terminated by signal") ||
           message.includes("Failed to write to process stdin"));
+      // Either way the query iterator is finished and the consumer is exiting,
+      // so release its resources via closeQueryStream (idempotent). A process
+      // death is unrecoverable, so additionally evict the session so the client
+      // starts fresh; other stream errors keep the session so prompt()/cancel()
+      // can answer with a clear "session ended" error.
       if (processDied) {
         this.logger.error(`Session ${params.sessionId}: Claude Agent process died: ${message}`);
         failAllTurns(
@@ -1903,19 +1908,12 @@ export class ClaudeAcpAgent implements Agent {
             "The Claude Agent process exited unexpectedly. Please start a new session.",
           ),
         );
-        session.settingsManager.dispose();
-        session.input.end();
+        this.closeQueryStream(session);
         delete this.sessions[params.sessionId];
       } else {
         this.logger.error(`Session ${params.sessionId}: query stream error: ${message}`);
         failAllTurns(error);
-        // query.next() threw, so the iterator is finished and the consumer is
-        // exiting. Mark the stream closed and drop the consumer handle so a
-        // later prompt() rejects up front instead of awaiting a deferred that
-        // no running consumer will ever settle (the early-return in
-        // ensureConsumer would otherwise see a truthy-but-dead consumer).
-        session.queryClosed = true;
-        session.consumer = undefined;
+        this.closeQueryStream(session);
       }
     }
   }
@@ -1923,6 +1921,13 @@ export class ClaudeAcpAgent implements Agent {
   async cancel(params: CancelNotification): Promise<void> {
     const session = this.sessions[params.sessionId];
     if (!session) {
+      return;
+    }
+    // The stream already ended (see closeQueryStream): every in-flight turn was
+    // settled when it closed, and there is no live query to interrupt. Calling
+    // query.interrupt() on a finished iterator could reject and surface from
+    // this fire-and-forget notification, so there is nothing to do here.
+    if (session.queryClosed) {
       return;
     }
     session.cancelled = true;
@@ -1971,8 +1976,27 @@ export class ClaudeAcpAgent implements Agent {
     await session.query.interrupt();
   }
 
-  /** Cleanly tear down a session: cancel in-flight work, dispose resources,
-   *  and remove it from the session map. */
+  /** Mark a session's SDK query stream as permanently ended and release the
+   *  resources tied to it: drop the consumer handle, dispose the settings
+   *  watchers, and end the input stream. The query iterator is not revivable, so
+   *  `prompt()`/`cancel()` consult `queryClosed` and fail/short-circuit instead
+   *  of acting on a dead stream. Idempotent (guarded by `queryClosed`), so the
+   *  consumer's done/error paths and a later `teardownSession` can all call it
+   *  without double-disposing. Does NOT remove the session from the map — that
+   *  is `teardownSession`'s job — so prompt() can still answer with a clear
+   *  "session ended" error after an unexpected stream close. */
+  private closeQueryStream(session: Session): void {
+    if (session.queryClosed) {
+      return;
+    }
+    session.queryClosed = true;
+    session.consumer = undefined;
+    session.settingsManager.dispose();
+    session.input.end();
+  }
+
+  /** Cleanly tear down a session: cancel in-flight work, release stream
+   *  resources, and remove it from the session map. */
   private async teardownSession(sessionId: string): Promise<void> {
     const session = this.sessions[sessionId];
     if (!session) {
@@ -1991,7 +2015,7 @@ export class ClaudeAcpAgent implements Agent {
       session.forceCancelTimer = undefined;
     }
     session.cancelController?.abort();
-    session.settingsManager.dispose();
+    this.closeQueryStream(session);
     session.abortController.abort();
     session.query.close();
     delete this.sessions[sessionId];

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -200,6 +200,12 @@ type Session = {
    *  kept alive for the session so between-turn/background messages are still
    *  drained and forwarded. */
   consumer?: Promise<void>;
+  /** Set once the SDK query stream has terminated (it ran to `done` or threw a
+   *  non-process error). The query iterator is not reusable afterward, so a
+   *  later `prompt()` rejects instead of enqueueing onto a dead stream and
+   *  hanging (or silently restarting a consumer that resolves `end_turn`
+   *  without ever reaching the model). */
+  queryClosed?: boolean;
   cwd: string;
   /** Serialized snapshot of session-defining params (cwd, mcpServers) used to
    *  detect when loadSession/resumeSession is called with changed values. */
@@ -846,6 +852,15 @@ export class ClaudeAcpAgent implements Agent {
     if (!session) {
       throw new Error("Session not found");
     }
+    // The SDK query stream already terminated (see `queryClosed`); its iterator
+    // can't be revived, so enqueueing here would hang on a deferred that never
+    // settles. Fail clearly and let the client start a fresh session.
+    if (session.queryClosed) {
+      throw RequestError.internalError(
+        undefined,
+        "The Claude Agent session has ended. Please start a new session.",
+      );
+    }
 
     const userMessage = promptToClaude(params);
     const promptUuid = randomUUID();
@@ -969,13 +984,20 @@ export class ClaudeAcpAgent implements Agent {
     };
 
     /** Ensure there is an active turn before a result that carries no echo
-     *  (local-only commands) by promoting the queue head. */
+     *  (local-only commands) by promoting the queue head. Only local-only
+     *  commands legitimately return a result without a user-message echo to
+     *  activate them; a normal turn is always activated by its echo before its
+     *  result. So if the head is NOT a local-only command, leave activeTurn
+     *  unset: such a result is an orphan (e.g. the SDK still ran a queued turn
+     *  that cancel() already resolved, since its user message was pushed before
+     *  the cancel) and promoting the head would misattribute the orphan's stop
+     *  reason and usage to an unrelated queued prompt. */
     const ensureActiveTurn = () => {
       if (session.activeTurn) {
         return;
       }
       const head = (session.turnQueue ?? []).find((t) => !t.settled);
-      if (head) {
+      if (head?.isLocalOnlyCommand) {
         activateTurn(head);
       }
     };
@@ -1072,26 +1094,41 @@ export class ClaudeAcpAgent implements Agent {
         const { value: message, done } = raced.result as IteratorResult<SDKMessage, void>;
 
         if (done || !message) {
-          // The stream ended. Settle any in-flight turns so no prompt() hangs:
+          // The stream ended. The query iterator can't be revived, so mark the
+          // session closed; a later prompt() rejects up front rather than
+          // restarting a consumer on the exhausted stream (which would resolve
+          // end_turn without ever reaching the model).
+          session.queryClosed = true;
+          // Settle the turn that was in flight so its prompt() doesn't hang:
           // cancelled if a cancel is pending, otherwise the accumulated outcome.
           settleActive(
             session.cancelled
               ? { stopReason: "cancelled" }
               : { stopReason, usage: sessionUsage(session) },
           );
+          // Queued turns the SDK never started: a cancel turns them into
+          // "cancelled", but otherwise the stream died before they ran, so
+          // reject them rather than reporting a success (end_turn) for a prompt
+          // that produced no output.
           for (const queued of [...(session.turnQueue ?? [])]) {
             if (!queued.settled) {
               queued.settled = true;
-              queued.resolve(
-                session.cancelled ? { stopReason: "cancelled" } : { stopReason: "end_turn" },
-              );
+              if (session.cancelled) {
+                queued.resolve({ stopReason: "cancelled" });
+              } else {
+                queued.reject(
+                  RequestError.internalError(
+                    undefined,
+                    "The Claude Agent session ended before this prompt ran. Please start a new session.",
+                  ),
+                );
+              }
             }
           }
           session.turnQueue = [];
-          // The query is exhausted. If the session is still around (the SDK
-          // closed the stream without us tearing it down), drop the finished
-          // consumer handle so a later prompt restarts one rather than awaiting
-          // a deferred that will never settle.
+          // Drop the finished consumer handle. With queryClosed set, prompt()
+          // won't restart it, but clearing keeps the dead promise from being
+          // mistaken for a live consumer.
           session.consumer = undefined;
           return;
         }
@@ -1193,14 +1230,20 @@ export class ClaudeAcpAgent implements Agent {
               }
               case "session_state_changed": {
                 if (message.state === "idle") {
-                  // `idle` is the authoritative turn-over signal. Settle the
-                  // active turn here; the consumer keeps running for subsequent
-                  // turns and background work rather than returning.
-                  settleActive(
-                    session.cancelled
-                      ? { stopReason: "cancelled" }
-                      : { stopReason, usage: sessionUsage(session) },
-                  );
+                  // A non-cancelled turn already settled at its terminal
+                  // `result` (issue #773), so this trailing `idle` is just
+                  // absorbed. We must NOT settle `activeTurn` here in that case:
+                  // `idle` carries no turn identity, and it can lag (the SDK
+                  // flushes held-back results / drains background agents first),
+                  // so by the time it arrives the SDK may have echoed the NEXT
+                  // turn and activated it — settling now would resolve that new
+                  // turn prematurely with end_turn and ~zero usage, dropping its
+                  // real result. Only a cancelled turn relies on `idle`: its
+                  // `result` is dropped at the `session.cancelled` guard, so it
+                  // never settles at a result and must settle here.
+                  if (session.cancelled) {
+                    settleActive({ stopReason: "cancelled" });
+                  }
                 }
                 break;
               }
@@ -1355,11 +1398,19 @@ export class ClaudeAcpAgent implements Agent {
               ensureActiveTurn();
             }
 
-            // Accumulate usage from this result
-            session.accumulatedUsage.inputTokens += message.usage.input_tokens;
-            session.accumulatedUsage.outputTokens += message.usage.output_tokens;
-            session.accumulatedUsage.cachedReadTokens += message.usage.cache_read_input_tokens;
-            session.accumulatedUsage.cachedWriteTokens += message.usage.cache_creation_input_tokens;
+            // Accumulate usage into the user turn's tally. Skip task-notification
+            // followups: their cost is real but is reported separately via the
+            // usage_update below, and `session.accumulatedUsage` is only reset on
+            // turn activation — so folding a task-notification result that lands
+            // after the next turn is active (but before it settles) would leak
+            // those tokens into that turn's PromptResponse.usage.
+            if (!isTaskNotification) {
+              session.accumulatedUsage.inputTokens += message.usage.input_tokens;
+              session.accumulatedUsage.outputTokens += message.usage.output_tokens;
+              session.accumulatedUsage.cachedReadTokens += message.usage.cache_read_input_tokens;
+              session.accumulatedUsage.cachedWriteTokens +=
+                message.usage.cache_creation_input_tokens;
+            }
 
             const matchingModelUsage = lastAssistantModel
               ? getMatchingModelUsage(message.modelUsage, lastAssistantModel)
@@ -1858,6 +1909,13 @@ export class ClaudeAcpAgent implements Agent {
       } else {
         this.logger.error(`Session ${params.sessionId}: query stream error: ${message}`);
         failAllTurns(error);
+        // query.next() threw, so the iterator is finished and the consumer is
+        // exiting. Mark the stream closed and drop the consumer handle so a
+        // later prompt() rejects up front instead of awaiting a deferred that
+        // no running consumer will ever settle (the early-return in
+        // ensureConsumer would otherwise see a truthy-but-dead consumer).
+        session.queryClosed = true;
+        session.consumer = undefined;
       }
     }
   }

--- a/src/acp-agent.ts
+++ b/src/acp-agent.ts
@@ -166,10 +166,40 @@ type SessionModelState = {
   currentModelId: string;
 };
 
+/** One in-flight `prompt()` call. A persistent per-session consumer (see
+ *  `runConsumer`) drains the SDK query stream for the whole session and settles
+ *  each Turn's deferred when that turn's outcome is known, so `prompt()` itself
+ *  holds no loop. Turns are processed FIFO: the SDK echoes queued user messages
+ *  back in submission order, so `turnQueue[0]` is the turn currently running. */
+type Turn = {
+  /** uuid stamped on the pushed `SDKUserMessage`; the SDK echoes it back so the
+   *  consumer can match the replayed user message to this turn. */
+  promptUuid: string;
+  /** Local-only slash commands (e.g. `/clear`) return a result without an echo,
+   *  so the consumer can't promote them via the replay; it falls back to
+   *  promoting the queue head when the result arrives. */
+  isLocalOnlyCommand: boolean;
+  /** Set once the deferred has been resolved/rejected, so the consumer never
+   *  settles a turn twice (idle + handoff + stream-end can all race). */
+  settled: boolean;
+  resolve: (response: PromptResponse) => void;
+  reject: (error: unknown) => void;
+};
+
 type Session = {
   query: Query;
   input: Pushable<SDKUserMessage>;
   cancelled: boolean;
+  /** FIFO of in-flight prompts. The head is the turn the SDK is currently
+   *  processing; later entries are queued and will be echoed in order. */
+  turnQueue?: Turn[];
+  /** The turn whose messages the consumer is currently attributing output to
+   *  (the head of `turnQueue` once its user message has been echoed). */
+  activeTurn?: Turn | null;
+  /** The long-lived consumer task. Lazily started on the first `prompt()` and
+   *  kept alive for the session so between-turn/background messages are still
+   *  drained and forwarded. */
+  consumer?: Promise<void>;
   cwd: string;
   /** Serialized snapshot of session-defining params (cwd, mcpServers) used to
    *  detect when loadSession/resumeSession is called with changed values. */
@@ -180,19 +210,16 @@ type Session = {
   models: SessionModelState;
   modelInfos: ModelInfo[];
   configOptions: SessionConfigOption[];
-  promptRunning: boolean;
-  pendingMessages: Map<string, { resolve: (cancelled: boolean) => void; order: number }>;
-  nextPendingOrder: number;
   abortController: AbortController;
-  /** Per-turn signal the active prompt loop races `query.next()` against.
-   *  Aborted by cancel() (after a grace period) to force the loop to return
-   *  "cancelled" when the SDK is wedged and `query.next()` never yields again
-   *  (issue #680). Distinct from `abortController`: this only wakes the loop;
-   *  it does NOT touch the SDK query/subprocess. Undefined when no prompt is
-   *  actively consuming the query. */
+  /** Signal the consumer races `query.next()` against. Aborted by cancel()
+   *  (after a grace period) to force the active turn to settle "cancelled" when
+   *  the SDK is wedged and `query.next()` never yields again (issue #680).
+   *  Distinct from `abortController`: this only wakes the consumer; it does NOT
+   *  touch the SDK query/subprocess. The consumer re-arms it after each fire.
+   *  Undefined until the consumer is started by the first prompt. */
   cancelController?: AbortController;
-  /** Pending grace-period timer that aborts `cancelController`. Cleared when
-   *  the loop returns normally so the backstop never fires after a clean
+  /** Pending grace-period timer that aborts `cancelController`. Cleared when the
+   *  active turn settles normally so the backstop never fires after a clean
    *  cancel. */
   forceCancelTimer?: ReturnType<typeof setTimeout>;
   emitRawSDKMessages: boolean | SDKMessageFilter[];
@@ -820,121 +847,253 @@ export class ClaudeAcpAgent implements Agent {
       throw new Error("Session not found");
     }
 
-    session.cancelled = false;
-    session.accumulatedUsage = {
-      inputTokens: 0,
-      outputTokens: 0,
-      cachedReadTokens: 0,
-      cachedWriteTokens: 0,
-    };
+    const userMessage = promptToClaude(params);
+    const promptUuid = randomUUID();
+    userMessage.uuid = promptUuid;
 
+    // Local-only commands (e.g. `/clear`) return a result without replaying the
+    // user message, so the consumer can't promote the turn from the echo.
+    const firstText = params.prompt[0]?.type === "text" ? params.prompt[0].text : "";
+    const isLocalOnlyCommand =
+      firstText.startsWith("/") && LOCAL_ONLY_COMMANDS.has(firstText.split(" ", 1)[0]);
+
+    // Each prompt is a Turn whose deferred the persistent consumer settles once
+    // the turn's outcome is known. `prompt()` owns no loop: it enqueues the
+    // turn, pushes the user message onto the streaming input, makes sure the
+    // consumer is running, and awaits the deferred.
+    const turn: Turn = {
+      promptUuid,
+      isLocalOnlyCommand,
+      settled: false,
+      resolve: () => {},
+      reject: () => {},
+    };
+    const response = new Promise<PromptResponse>((resolve, reject) => {
+      turn.resolve = resolve;
+      turn.reject = reject;
+    });
+
+    session.turnQueue ??= [];
+    session.turnQueue.push(turn);
+    session.input.push(userMessage);
+    this.ensureConsumer(session, params.sessionId);
+    return response;
+  }
+
+  /** Lazily start the per-session consumer that drains the SDK query stream for
+   *  the session's whole life. Idempotent: only the first `prompt()` starts it. */
+  private ensureConsumer(session: Session, sessionId: string): void {
+    if (session.consumer) {
+      return;
+    }
+    // Wake-up channel so cancel() can force the consumer to settle the active
+    // turn "cancelled" even when query.next() is wedged and never yields again
+    // (issue #680). The consumer re-arms it after each fire.
+    session.cancelController = new AbortController();
+    session.consumer = this.runConsumer(session, { sessionId });
+    session.consumer.catch((error) => {
+      this.logger.error(`Session ${sessionId}: consumer terminated unexpectedly: ${error}`);
+    });
+  }
+
+  /** The single, long-lived consumer of the SDK query stream for a session. It
+   *  forwards every message as ACP `sessionUpdate`s (so background/between-turn
+   *  output streams live, not just while a prompt is awaiting) and settles each
+   *  Turn's deferred when that turn ends. Replaces the per-prompt message loop;
+   *  `params` only carries the (session-invariant) `sessionId`. */
+  private async runConsumer(session: Session, params: { sessionId: string }): Promise<void> {
+    // Per-turn scratch, reset whenever a turn becomes active. Kept as consumer
+    // locals (rather than per-Turn fields) because they describe the message
+    // currently being processed, which is sequential — exactly one turn is
+    // active at a time. Mirrors the locals the old per-prompt loop held.
     let lastAssistantTotalUsage: number | null = null;
     let lastAssistantUsage: UsageSnapshot | null = null;
     let lastAssistantModel: string | null = null;
     // When the Claude SDK classifies a turn as failed (e.g. rate limit, auth
     // problem, billing), it sets a categorical `error` field on the
-    // `SDKAssistantMessage` that precedes the final `result` message. We
-    // capture it here so the subsequent `RequestError.internalError` can
-    // forward it to clients as structured `data`, sparing them from
-    // pattern-matching on the human-readable message text.
+    // `SDKAssistantMessage` that precedes the final `result` message. We capture
+    // it here so the subsequent `RequestError.internalError` can forward it to
+    // clients as structured `data`, sparing them from pattern-matching on text.
     let lastAssistantError: SDKAssistantMessageError | undefined;
     // When a streaming classifier refuses a turn, the assistant message carries
     // stop_reason "refusal" and structured stop_details. We capture the
-    // human-readable explanation here so the terminal `result` can surface it
-    // to the user (the refused assistant message itself usually has no content)
-    // and report ACP's dedicated `refusal` stop reason.
+    // human-readable explanation so the terminal `result` can surface it.
     let lastRefusalExplanation: string | null = null;
     // Tracks whether we're inside a compaction. The SDK emits the terminal
     // `status` (compact_result success/failed) twice for a single failed
     // compaction, and the two messages are indistinguishable — so we report the
-    // outcome only while a compaction is in progress, then clear this. A fresh
-    // `compacting` status sets it again, so every distinct compaction (e.g.
-    // repeated auto-compactions in a long turn) is still shown.
+    // outcome only while a compaction is in progress, then clear this.
     let compactionInProgress = false;
-    // Holds the Anthropic API message id of the assistant message currently
-    // being streamed, captured from `message_start` so every streamed chunk can
-    // be tagged with it. We use the API message id rather than the
-    // per-`stream_event` uuid because the same id is also present on the
-    // consolidated assistant message and in the persisted transcript — so a turn
-    // keeps the same ACP `messageId` whether it is streamed live or replayed
-    // from history. The per-event uuid is unique per event and never persisted.
-    // A single value suffices because every streaming partial arrives with
-    // `parent_tool_use_id === null` (subagent work is folded into tool-result
-    // messages, never surfaced as partial streams).
+    // Anthropic API message id of the assistant message currently being
+    // streamed, captured from `message_start` so the streamed chunks that follow
+    // (whose delta events don't carry it) can all be tagged with the same,
+    // replay-stable id.
     let currentStreamMessageId: string | undefined;
-    // Per-message-id record of which assistant content actually streamed live via
-    // `stream_event` deltas, split by block type. The `assistant` case below
-    // normally drops `text`/`thinking` blocks on the assumption they already
-    // reached the client as `agent_message_chunk`/`agent_thought_chunk`. That
-    // breaks behind Anthropic-protocol gateways that return a turn as a single
-    // non-streamed block (common with OpenAI-compatible proxies): no
-    // `content_block_delta` fires, so the assembled block is the only copy the
-    // client will ever see. We keep the filter per (id, block type) for content
-    // that did stream, and fall back to forwarding what did not. Split by type so
-    // a gateway that streams text but not thinking (or vice versa) doesn't lose
-    // the un-streamed block. Only top-level (`parent_tool_use_id === null`)
-    // streams are recorded — subagent text is never streamed and must stay
-    // filtered, as it is internal to the tool call.
-    const streamedTextIds = new Set<string>();
-    const streamedThinkingIds = new Set<string>();
-
-    const userMessage = promptToClaude(params);
-
-    const promptUuid = randomUUID();
-    userMessage.uuid = promptUuid;
-
-    // These local-only commands return a result without replaying the user
-    // message. Mark promptReplayed=true so their result isn't consumed as a
-    // background task result.
-    const firstText = params.prompt[0]?.type === "text" ? params.prompt[0].text : "";
-    const isLocalOnlyCommand =
-      firstText.startsWith("/") && LOCAL_ONLY_COMMANDS.has(firstText.split(" ", 1)[0]);
-
-    if (session.promptRunning) {
-      session.input.push(userMessage);
-      const order = session.nextPendingOrder++;
-      const cancelled = await new Promise<boolean>((resolve) => {
-        session.pendingMessages.set(promptUuid, { resolve, order });
-      });
-      if (cancelled) {
-        return { stopReason: "cancelled" };
-      }
-    } else {
-      session.input.push(userMessage);
-    }
-
-    session.promptRunning = true;
-    let handedOff = false;
-    let errored = false;
+    // Per-message-id record of which assistant content actually streamed live
+    // via `stream_event` deltas, split by block type, so the consolidated
+    // `assistant` message can drop the duplicate blocks that already reached the
+    // client as chunks while still forwarding any that a non-streaming gateway
+    // delivered only as an assembled block.
+    let streamedTextIds = new Set<string>();
+    let streamedThinkingIds = new Set<string>();
+    // Stop reason accumulated for the active turn (result subtype, refusal,
+    // max_tokens, …). Reset per turn; read when the turn settles at idle.
     let stopReason: StopReason = "end_turn";
 
-    // Wake-up channel so cancel() can force this loop to return "cancelled"
-    // even when query.next() is wedged and never yields again (issue #680).
-    const cancelController = new AbortController();
-    session.cancelController = cancelController;
-    const cancelled = new Promise<void>((resolve) => {
-      cancelController.signal.addEventListener("abort", () => resolve(), { once: true });
-    });
+    const resetTurnScratch = () => {
+      lastAssistantTotalUsage = null;
+      lastAssistantUsage = null;
+      lastAssistantModel = null;
+      lastAssistantError = undefined;
+      lastRefusalExplanation = null;
+      compactionInProgress = false;
+      currentStreamMessageId = undefined;
+      streamedTextIds = new Set<string>();
+      streamedThinkingIds = new Set<string>();
+      stopReason = "end_turn";
+      session.accumulatedUsage = {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      };
+    };
+
+    /** Promote a queued turn to active: it becomes the one output is attributed
+     *  to, and its scratch starts fresh. Clears the cancelled flag so a turn
+     *  enqueued after a prior cancel isn't treated as cancelled. */
+    const activateTurn = (turn: Turn) => {
+      session.activeTurn = turn;
+      session.cancelled = false;
+      resetTurnScratch();
+    };
+
+    /** Ensure there is an active turn before a result that carries no echo
+     *  (local-only commands) by promoting the queue head. */
+    const ensureActiveTurn = () => {
+      if (session.activeTurn) {
+        return;
+      }
+      const head = (session.turnQueue ?? []).find((t) => !t.settled);
+      if (head) {
+        activateTurn(head);
+      }
+    };
+
+    /** Settle the active turn's deferred exactly once, disarm the force-cancel
+     *  backstop (the turn is over), and drop it from the queue. */
+    const settleActive = (result: PromptResponse) => {
+      const turn = session.activeTurn;
+      if (!turn || turn.settled) {
+        return;
+      }
+      turn.settled = true;
+      if (session.forceCancelTimer) {
+        clearTimeout(session.forceCancelTimer);
+        session.forceCancelTimer = undefined;
+      }
+      session.turnQueue = (session.turnQueue ?? []).filter((t) => t !== turn);
+      session.activeTurn = null;
+      turn.resolve(result);
+    };
+
+    /** Reject the active turn (auth required, error result, …) without tearing
+     *  down the consumer: the stream continues to idle and later turns proceed. */
+    const failActive = (error: unknown) => {
+      if (session.forceCancelTimer) {
+        clearTimeout(session.forceCancelTimer);
+        session.forceCancelTimer = undefined;
+      }
+      const turn = session.activeTurn;
+      if (!turn || turn.settled) {
+        return;
+      }
+      turn.settled = true;
+      session.turnQueue = (session.turnQueue ?? []).filter((t) => t !== turn);
+      session.activeTurn = null;
+      turn.reject(error);
+    };
+
+    /** Reject every in-flight turn — used when the stream dies. */
+    const failAllTurns = (error: unknown) => {
+      if (session.forceCancelTimer) {
+        clearTimeout(session.forceCancelTimer);
+        session.forceCancelTimer = undefined;
+      }
+      const turns = session.activeTurn
+        ? [session.activeTurn, ...(session.turnQueue ?? []).filter((t) => t !== session.activeTurn)]
+        : [...(session.turnQueue ?? [])];
+      session.activeTurn = null;
+      session.turnQueue = [];
+      for (const turn of turns) {
+        if (!turn.settled) {
+          turn.settled = true;
+          turn.reject(error);
+        }
+      }
+    };
+
+    // The wake-up channel cancel()/teardown aborts to force the active turn to
+    // settle "cancelled" even when query.next() is wedged (issue #680). Re-armed
+    // after each fire so the consumer keeps serving later turns.
+    let cancelController = session.cancelController!;
 
     try {
       while (true) {
         const nextMessage = session.query.next();
-        const next = await Promise.race([nextMessage, cancelled]);
-        if (cancelController.signal.aborted) {
-          // The SDK never yielded after interrupt() (e.g. a wedged TaskOutput
-          // block). Abandon the in-flight next() — swallowing any later
-          // rejection so it can't surface as an unhandled rejection — and
-          // honor the cancel per the ACP contract.
+        // Fresh abort listener per iteration, removed when next() wins, so a
+        // long-lived session doesn't accumulate listeners on one signal.
+        let onAbort!: () => void;
+        const abortRace = new Promise<"abort">((resolve) => {
+          onAbort = () => resolve("abort");
+          cancelController.signal.addEventListener("abort", onAbort, { once: true });
+        });
+        const raced = await Promise.race([
+          nextMessage.then((result) => ({ kind: "message" as const, result })),
+          abortRace,
+        ]);
+        cancelController.signal.removeEventListener("abort", onAbort);
+
+        if (raced === "abort") {
+          // cancel()/teardown woke us. Abandon the in-flight next() (swallowing
+          // any later rejection so it can't surface as unhandled) and settle the
+          // active turn "cancelled" per the ACP contract. If the session is
+          // being torn down, stop; otherwise re-arm and keep consuming.
           void nextMessage.catch(() => {});
-          return { stopReason: "cancelled" };
+          settleActive({ stopReason: "cancelled" });
+          if (!this.sessions[params.sessionId]) {
+            return;
+          }
+          cancelController = new AbortController();
+          session.cancelController = cancelController;
+          continue;
         }
-        const { value: message, done } = next as IteratorResult<SDKMessage, void>;
+
+        const { value: message, done } = raced.result as IteratorResult<SDKMessage, void>;
 
         if (done || !message) {
-          if (session.cancelled) {
-            return { stopReason: "cancelled" };
+          // The stream ended. Settle any in-flight turns so no prompt() hangs:
+          // cancelled if a cancel is pending, otherwise the accumulated outcome.
+          settleActive(
+            session.cancelled
+              ? { stopReason: "cancelled" }
+              : { stopReason, usage: sessionUsage(session) },
+          );
+          for (const queued of [...(session.turnQueue ?? [])]) {
+            if (!queued.settled) {
+              queued.settled = true;
+              queued.resolve(
+                session.cancelled ? { stopReason: "cancelled" } : { stopReason: "end_turn" },
+              );
+            }
           }
-          break;
+          session.turnQueue = [];
+          // The query is exhausted. If the session is still around (the SDK
+          // closed the stream without us tearing it down), drop the finished
+          // consumer handle so a later prompt restarts one rather than awaiting
+          // a deferred that will never settle.
+          session.consumer = undefined;
+          return;
         }
 
         if (
@@ -1034,10 +1193,14 @@ export class ClaudeAcpAgent implements Agent {
               }
               case "session_state_changed": {
                 if (message.state === "idle") {
-                  if (session.cancelled) {
-                    stopReason = "cancelled";
-                  }
-                  return { stopReason, usage: sessionUsage(session) };
+                  // `idle` is the authoritative turn-over signal. Settle the
+                  // active turn here; the consumer keeps running for subsequent
+                  // turns and background work rather than returning.
+                  settleActive(
+                    session.cancelled
+                      ? { stopReason: "cancelled" }
+                      : { stopReason, usage: sessionUsage(session) },
+                  );
                 }
                 break;
               }
@@ -1177,6 +1340,21 @@ export class ClaudeAcpAgent implements Agent {
             }
             break;
           case "result": {
+            // Task-notification followups are autonomous work triggered by a
+            // task-notification system message, not by the user's prompt.
+            // They should not influence the user-turn lifecycle (stop reason,
+            // slash-command output forwarding) but their cost is real.
+            const isTaskNotification = message.origin?.kind === "task-notification";
+
+            // A user-turn result needs an active turn so its stop reason is
+            // attributed and the turn settles at idle. Local-only commands carry
+            // no user-message echo to promote them, so do it here from the head.
+            // Promote BEFORE accumulating usage, since activation resets the
+            // accumulator — promoting after would discard this result's tokens.
+            if (!isTaskNotification) {
+              ensureActiveTurn();
+            }
+
             // Accumulate usage from this result
             session.accumulatedUsage.inputTokens += message.usage.input_tokens;
             session.accumulatedUsage.outputTokens += message.usage.output_tokens;
@@ -1193,12 +1371,6 @@ export class ClaudeAcpAgent implements Agent {
             if (matchingModelUsage) {
               session.contextWindowSize = matchingModelUsage.contextWindow;
             }
-
-            // Task-notification followups are autonomous work triggered by a
-            // task-notification system message, not by the user's prompt.
-            // They should not influence the user-turn lifecycle (stop reason,
-            // slash-command output forwarding) but their cost is real.
-            const isTaskNotification = message.origin?.kind === "task-notification";
 
             // Send usage_update notification
             if (lastAssistantTotalUsage !== null) {
@@ -1249,7 +1421,8 @@ export class ClaudeAcpAgent implements Agent {
             switch (message.subtype) {
               case "success": {
                 if (message.result.includes("Please run /login")) {
-                  throw RequestError.authRequired();
+                  failActive(RequestError.authRequired());
+                  break;
                 }
                 if (message.stop_reason === "max_tokens") {
                   if (!isTaskNotification) {
@@ -1258,16 +1431,16 @@ export class ClaudeAcpAgent implements Agent {
                   break;
                 }
                 if (message.is_error) {
-                  throw RequestError.internalError(
-                    errorKindData(lastAssistantError),
-                    message.result,
+                  failActive(
+                    RequestError.internalError(errorKindData(lastAssistantError), message.result),
                   );
+                  break;
                 }
                 // For local-only commands (no model invocation), the result
                 // text is the command output — forward it to the client.
                 // Task-notification followups never originate from a user
                 // slash command, so skip the forwarding for them.
-                if (isLocalOnlyCommand && !isTaskNotification) {
+                if (session.activeTurn?.isLocalOnlyCommand && !isTaskNotification) {
                   for (const notification of toAcpNotifications(
                     message.result,
                     "assistant",
@@ -1289,10 +1462,13 @@ export class ClaudeAcpAgent implements Agent {
                   break;
                 }
                 if (message.is_error) {
-                  throw RequestError.internalError(
-                    errorKindData(lastAssistantError),
-                    message.errors.join(", ") || message.subtype,
+                  failActive(
+                    RequestError.internalError(
+                      errorKindData(lastAssistantError),
+                      message.errors.join(", ") || message.subtype,
+                    ),
                   );
+                  break;
                 }
                 if (!isTaskNotification) {
                   stopReason = "end_turn";
@@ -1303,10 +1479,13 @@ export class ClaudeAcpAgent implements Agent {
               case "error_max_turns":
               case "error_max_structured_output_retries":
                 if (message.is_error) {
-                  throw RequestError.internalError(
-                    errorKindData(lastAssistantError),
-                    message.errors.join(", ") || message.subtype,
+                  failActive(
+                    RequestError.internalError(
+                      errorKindData(lastAssistantError),
+                      message.errors.join(", ") || message.subtype,
+                    ),
                   );
+                  break;
                 }
                 if (!isTaskNotification) {
                   stopReason = "max_turn_requests";
@@ -1411,38 +1590,45 @@ export class ClaudeAcpAgent implements Agent {
           }
           case "user":
           case "assistant": {
-            if (session.cancelled) {
-              break;
-            }
-
-            // Record the ACP messageId -> SDK uuid mapping for this message. The
-            // consolidated message carries both ids, so this is where we learn
-            // the uuid that the SDK's rewind/resume APIs key on for the id we
-            // hand clients. Not read yet (see Session.messageIdToUuid).
+            // Record the ACP messageId -> SDK uuid mapping for this message
+            // (including replays). The consolidated message carries both ids, so
+            // this is where we learn the uuid the SDK's rewind/resume APIs key on
+            // for the id we hand clients. Not read yet (see messageIdToUuid).
             const mappedMessageId = messageIdForGrouping(message);
             if (mappedMessageId && typeof message.uuid === "string" && message.uuid.length > 0) {
               session.messageIdToUuid.set(mappedMessageId, message.uuid);
             }
 
-            // Check for prompt replay
+            // A replayed user message echoes a queued turn back in submission
+            // order. The first echo promotes that turn to active; if a different
+            // turn is still active, it is handed off (settled end_turn) first.
+            // Done before the `cancelled` guard so a turn enqueued after a cancel
+            // is still promoted — activateTurn() clears the flag. The turn's own
+            // echo is then dropped from the feed (the client already shows it).
             if (message.type === "user" && "uuid" in message && message.uuid) {
-              if (message.uuid === promptUuid) {
+              const queued = (session.turnQueue ?? []).find(
+                (t) => t.promptUuid === message.uuid && !t.settled,
+              );
+              if (queued) {
+                // Only (re)activate if this isn't already the active turn — a
+                // turn promoted early (e.g. by a result that preceded its echo)
+                // must not have its accumulated usage reset by its own echo.
+                if (session.activeTurn !== queued) {
+                  if (session.activeTurn) {
+                    settleActive({ stopReason: "end_turn", usage: sessionUsage(session) });
+                  }
+                  activateTurn(queued);
+                }
                 break;
-              }
-
-              const pending = session.pendingMessages.get(message.uuid as string);
-              if (pending) {
-                pending.resolve(false);
-                session.pendingMessages.delete(message.uuid as string);
-                handedOff = true;
-                // the current loop stops with end_turn,
-                // the loop of the next prompt continues running
-                return { stopReason: "end_turn", usage: sessionUsage(session) };
               }
               if ("isReplay" in message && message.isReplay) {
-                // not pending or unrelated replay message
+                // Unrelated replay (e.g. the echo of an already-settled turn).
                 break;
               }
+            }
+
+            if (session.cancelled) {
+              break;
             }
 
             // Snapshot the latest top-level assistant usage and model so the
@@ -1527,7 +1713,8 @@ export class ClaudeAcpAgent implements Agent {
               message.message.content[0].type === "text" &&
               message.message.content[0].text.includes("Please run /login")
             ) {
-              throw RequestError.authRequired();
+              failActive(RequestError.authRequired());
+              break;
             }
 
             let content: typeof message.message.content;
@@ -1631,91 +1818,35 @@ export class ClaudeAcpAgent implements Agent {
             break;
         }
       }
-      throw new Error("Session did not end in result");
+      // `while (true)` only exits via the `done` return above or the catch
+      // below, so there is no normal fall-through here.
     } catch (error) {
-      errored = true;
-      // A failed turn typically leaves a trailing `session_state_changed: idle`
-      // (and possibly more) in the query iterator. If we don't drain it here,
-      // the next prompt's first `query.next()` consumes that stale idle and
-      // short-circuits to end_turn with zero usage
-      // Bounded so a misbehaving SDK can't hang the next prompt indefinitely.
-      try {
-        await session.query.interrupt();
-        const MAX_DRAIN = 100;
-        for (let i = 0; i < MAX_DRAIN; i++) {
-          const { value: m, done } = await session.query.next();
-          if (done || !m) break;
-          if (m.type === "system" && m.subtype === "session_state_changed" && m.state === "idle") {
-            break;
-          }
-          if (i === MAX_DRAIN - 1) {
-            this.logger.error(
-              `Session ${params.sessionId}: drained ${MAX_DRAIN} messages after error without observing idle`,
-            );
-          }
-        }
-      } catch (drainErr) {
-        this.logger.error(
-          `Session ${params.sessionId}: failed to drain query after prompt error:`,
-          drainErr,
-        );
-      }
-
-      if (error instanceof RequestError || !(error instanceof Error)) {
-        throw error;
-      }
-      const message = error.message;
-      if (
-        message.includes("ProcessTransport") ||
-        message.includes("terminated process") ||
-        message.includes("process exited with") ||
-        message.includes("process terminated by signal") ||
-        message.includes("Failed to write to process stdin")
-      ) {
+      // The query stream itself died (a transport/process error surfaced from
+      // query.next()). Turn-level failures (auth, error results) are handled
+      // inline via failActive and never reach here. Reject every in-flight turn;
+      // if the process is gone, tear the session down so the client starts fresh.
+      const message = error instanceof Error ? error.message : String(error);
+      const processDied =
+        error instanceof Error &&
+        (message.includes("ProcessTransport") ||
+          message.includes("terminated process") ||
+          message.includes("process exited with") ||
+          message.includes("process terminated by signal") ||
+          message.includes("Failed to write to process stdin"));
+      if (processDied) {
         this.logger.error(`Session ${params.sessionId}: Claude Agent process died: ${message}`);
+        failAllTurns(
+          RequestError.internalError(
+            undefined,
+            "The Claude Agent process exited unexpectedly. Please start a new session.",
+          ),
+        );
         session.settingsManager.dispose();
         session.input.end();
         delete this.sessions[params.sessionId];
-        throw RequestError.internalError(
-          undefined,
-          "The Claude Agent process exited unexpectedly. Please start a new session.",
-        );
-      }
-      throw error;
-    } finally {
-      // The loop is returning — interrupt() succeeded or the prompt finished
-      // — so disarm the force-cancel backstop and release the wake-up channel
-      // (only if we still own it; a handoff installs the next prompt's).
-      if (session.forceCancelTimer) {
-        clearTimeout(session.forceCancelTimer);
-        session.forceCancelTimer = undefined;
-      }
-      if (session.cancelController === cancelController) {
-        session.cancelController = undefined;
-      }
-      if (!handedOff) {
-        session.promptRunning = false;
-        if (errored) {
-          // The query stream was just drained — handing pending prompts off
-          // onto it would let them race with the recovery. Cancel them so
-          // each waiting prompt() returns stopReason: "cancelled" and the
-          // client can decide whether to retry.
-          for (const pending of session.pendingMessages.values()) {
-            pending.resolve(true);
-          }
-          session.pendingMessages.clear();
-        } else if (session.pendingMessages.size > 0) {
-          // This usually should not happen, but in case the loop finishes
-          // without claude sending all message replays, we resolve the
-          // next pending prompt call to ensure no prompts get stuck.
-          const next = [...session.pendingMessages.entries()].sort(
-            (a, b) => a[1].order - b[1].order,
-          )[0];
-          if (next) {
-            next[1].resolve(false);
-            session.pendingMessages.delete(next[0]);
-          }
-        }
+      } else {
+        this.logger.error(`Session ${params.sessionId}: query stream error: ${message}`);
+        failAllTurns(error);
       }
     }
   }
@@ -1726,24 +1857,35 @@ export class ClaudeAcpAgent implements Agent {
       return;
     }
     session.cancelled = true;
-    for (const [, pending] of session.pendingMessages) {
-      pending.resolve(true);
+    // Settle queued turns that haven't started yet (no echo seen) right away —
+    // they have no in-flight SDK work to interrupt. The active turn is settled
+    // by the consumer when it observes the interrupt's trailing idle (or via the
+    // backstop below). Mirrors the old pendingMessages cancellation.
+    if (session.turnQueue) {
+      for (const turn of session.turnQueue) {
+        if (turn !== session.activeTurn && !turn.settled) {
+          turn.settled = true;
+          turn.resolve({ stopReason: "cancelled" });
+        }
+      }
+      session.turnQueue = session.turnQueue.filter(
+        (turn) => turn === session.activeTurn && !turn.settled,
+      );
     }
-    session.pendingMessages.clear();
 
-    // Arm a backstop before interrupting: if a prompt is actively consuming
-    // the query and interrupt() doesn't make the SDK yield (e.g. a wedged
-    // TaskOutput block — issue #680), force the loop to return "cancelled"
-    // after the floor elapses so the pending session/prompt still resolves per
-    // the ACP cancellation contract instead of hanging forever. The loop's
-    // `finally` clears this timer when interrupt() works and it returns through
+    // Arm a backstop before interrupting: if a turn is actively consuming the
+    // query and interrupt() doesn't make the SDK yield (e.g. a wedged TaskOutput
+    // block — issue #680), force the consumer to settle the active turn
+    // "cancelled" after the floor elapses so the pending session/prompt still
+    // resolves per the ACP cancellation contract instead of hanging forever. The
+    // consumer clears this timer when interrupt() works and it settles through
     // the normal idle path, so on healthy cancels it is armed but never fires.
     //
-    // Arm at most once per turn: the floor is an absolute ceiling from the
-    // first cancel, so a client that re-sends cancel (each call still retries
+    // Arm at most once per turn: the floor is an absolute ceiling from the first
+    // cancel, so a client that re-sends cancel (each call still retries
     // interrupt() below) can't keep pushing the deadline out.
     if (
-      session.promptRunning &&
+      session.activeTurn &&
       session.cancelController &&
       !session.cancelController.signal.aborted &&
       !session.forceCancelTimer
@@ -1769,12 +1911,12 @@ export class ClaudeAcpAgent implements Agent {
     }
     await this.cancel({ sessionId });
     // cancel() arms the force-cancel floor and interrupts gracefully, but a
-    // wedged prompt loop only wakes when `cancelController` aborts — closing
-    // the query/abortController below doesn't touch it. Since we're tearing the
-    // session down anyway, wake the loop now so the in-flight prompt() resolves
-    // immediately instead of after the floor, and clear the timer so it can't
-    // outlive the deleted session (it isn't unref'd and would otherwise keep
-    // the event loop alive until it fires).
+    // wedged consumer only wakes when `cancelController` aborts — closing the
+    // query/abortController below doesn't touch it. Since we're tearing the
+    // session down anyway, wake the consumer now so the in-flight prompt()
+    // resolves immediately instead of after the floor, and clear the timer so it
+    // can't outlive the deleted session (it isn't unref'd and would otherwise
+    // keep the event loop alive until it fires).
     if (session.forceCancelTimer) {
       clearTimeout(session.forceCancelTimer);
       session.forceCancelTimer = undefined;
@@ -2782,9 +2924,6 @@ export class ClaudeAcpAgent implements Agent {
       models,
       modelInfos: allowedModels,
       configOptions,
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController,
       emitRawSDKMessages: sessionMeta?.claudeCode?.emitRawSDKMessages ?? false,
       contextWindowSize:

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4768,6 +4768,115 @@ describe("post-error recovery", () => {
     await expect(first).resolves.toEqual({ stopReason: "cancelled" });
     await expect(second).rejects.toThrow(/start a new session/);
   });
+
+  it("settles a no-echo command (/compact) submitted right after a cancel", async () => {
+    // Regression: after cancelling turn 1, session.cancelled lingers until the
+    // next activation. A /compact submitted next never echoes its uuid, so it
+    // can only be settled by head-promotion — which the old `!session.cancelled`
+    // gate blocked, hanging the prompt. The orphan-count gate promotes it (no
+    // orphans are expected since the cancel removed no queued turns).
+    const agent = createMockAgent();
+    let releaseAfterCancel!: () => void;
+    const afterCancel = new Promise<void>((resolve) => (releaseAfterCancel = resolve));
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn 1 active
+        await afterCancel; // wait until the test has cancelled turn 1
+        yield { type: "system", subtype: "session_state_changed", state: "idle" }; // settles turn 1 cancelled
+        await iter.next(); // /compact's pushed message — never echoed
+        yield {
+          type: "system",
+          subtype: "status",
+          status: "compacting",
+          session_id: "test-session",
+        };
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    await agent.cancel({ sessionId: "test-session" });
+    releaseAfterCancel();
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+
+    // session.cancelled is still true here (turn 1 settled, nothing re-activated).
+    // The /compact result must still settle via head-promotion.
+    const compact = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact" }],
+    });
+    expect(compact.stopReason).toBe("end_turn");
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("skips the orphan result of a cancelled queued turn instead of misattributing it", async () => {
+    // Turn 1 active, turn 2 queued. cancel() settles+removes turn 2 but its
+    // message was already pushed, so the SDK still emits turn 2's result (an
+    // orphan). That orphan must be SKIPPED — not promoted onto the next prompt —
+    // so a later turn 3 resolves with its OWN usage, not the orphan's.
+    const agent = createMockAgent();
+    let afterCancelAndQueue!: () => void;
+    const gate = new Promise<void>((resolve) => (afterCancelAndQueue = resolve));
+
+    const orphanResult = createResultMessage({
+      subtype: "success",
+      stop_reason: "end_turn",
+      is_error: false,
+    });
+    orphanResult.usage.input_tokens = 999; // distinct so misattribution is visible
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn 1 active
+        await iter.next(); // turn 2's pushed message (will be cancelled+removed)
+        await gate; // wait until the test cancels (removing turn 2) and queues turn 3
+        yield { type: "system", subtype: "session_state_changed", state: "idle" }; // turn 1 settles cancelled
+        yield orphanResult; // turn 2's orphan result — must be skipped, not promote turn 3
+        const u3 = await iter.next();
+        yield userEcho(u3.value); // turn 3 echo activates it
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false }); // usage 10
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    await waitFor(() => (agent.sessions["test-session"]?.turnQueue?.length ?? 0) >= 2);
+
+    await agent.cancel({ sessionId: "test-session" }); // removes turn 2 -> pendingOrphanResults = 1
+    const third = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "third" }],
+    });
+    afterCancelAndQueue();
+
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(second).resolves.toEqual({ stopReason: "cancelled" });
+    const thirdResult = await third;
+    expect(thirdResult.stopReason).toBe("end_turn");
+    // Turn 3's own result carries 10 input tokens; the orphan's 999 must not leak.
+    expect(thirdResult.usage?.inputTokens).toBe(10);
+    await agent.sessions["test-session"]?.consumer;
+  });
 });
 
 describe("session/cancel wedge recovery (issue #680)", () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1699,9 +1699,6 @@ describe("stop reason propagation", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -1846,9 +1843,6 @@ describe("stop reason propagation", () => {
       },
       abortController: new AbortController(),
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
       taskState: new Map(),
@@ -2006,9 +2000,6 @@ describe("session/close", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -2092,9 +2083,6 @@ describe("session/delete", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -2195,9 +2183,6 @@ describe("getOrCreateSession param change detection", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -2432,9 +2417,6 @@ describe("usage_update computation", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -3441,9 +3423,6 @@ describe("assembled assistant text fallback", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -3637,9 +3616,6 @@ describe("emitRawSDKMessages", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages,
       contextWindowSize: 200000,
@@ -3867,9 +3843,6 @@ describe("result origin handling", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -4044,9 +4017,6 @@ describe("memory_recall handling", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -4276,9 +4246,6 @@ describe("post-error recovery", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,
@@ -4291,16 +4258,16 @@ describe("post-error recovery", () => {
 
   it("drains a failed turn's trailing idle so the next prompt is not short-circuited", async () => {
     const agent = createMockAgent();
-    const { interrupt } = injectTwoTurnSession(agent, [
+    injectTwoTurnSession(agent, [
       createResultMessage({
         subtype: "success",
         stop_reason: "end_turn",
         is_error: true,
         result: "boom",
       }),
-      // Trailing idle from the failed turn. Without draining, the next
-      // prompt's first query.next() would consume this and short-circuit
-      // to end_turn with zero usage (issue #654).
+      // Trailing idle from the failed turn. The persistent consumer keeps
+      // reading and absorbs this idle (no active turn to settle), so the next
+      // prompt starts clean rather than consuming a stale idle (issue #654).
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
@@ -4311,8 +4278,6 @@ describe("post-error recovery", () => {
       }),
     ).rejects.toThrow();
 
-    expect(interrupt).toHaveBeenCalled();
-
     const second = await agent.prompt({
       sessionId: "test-session",
       prompt: [{ type: "text", text: "second" }],
@@ -4322,7 +4287,7 @@ describe("post-error recovery", () => {
     expect(second.usage?.outputTokens).toBe(5);
   });
 
-  it("cancels all queued pending prompts when a turn errors", async () => {
+  it("rejects only the failed turn; a queued prompt still runs", async () => {
     const agent = createMockAgent();
     injectTwoTurnSession(agent, [
       createResultMessage({
@@ -4334,27 +4299,42 @@ describe("post-error recovery", () => {
       { type: "system", subtype: "session_state_changed", state: "idle" },
     ]);
 
-    // Simulate two prompts already queued behind the running turn. Both
-    // resolvers should fire with `true` (cancelled) when the running
-    // prompt errors, and the map should be cleared.
-    const session = agent.sessions["test-session"];
-    let resolveA!: (cancelled: boolean) => void;
-    let resolveB!: (cancelled: boolean) => void;
-    const pendingA = new Promise<boolean>((r) => (resolveA = r));
-    const pendingB = new Promise<boolean>((r) => (resolveB = r));
-    session.pendingMessages.set("uuid-a", { resolve: resolveA, order: 0 });
-    session.pendingMessages.set("uuid-b", { resolve: resolveB, order: 1 });
+    // With a persistent consumer a turn-level error no longer poisons the
+    // stream, so a prompt queued behind the failing one runs to completion
+    // instead of being cancelled.
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
 
-    await expect(
-      agent.prompt({
-        sessionId: "test-session",
-        prompt: [{ type: "text", text: "first" }],
-      }),
-    ).rejects.toThrow();
+    await expect(first).rejects.toThrow();
+    await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+  });
 
-    await expect(pendingA).resolves.toBe(true);
-    await expect(pendingB).resolves.toBe(true);
-    expect(session.pendingMessages.size).toBe(0);
+  it("hands off to a queued prompt when the next turn starts without a trailing idle", async () => {
+    const agent = createMockAgent();
+    // turn 1 produces a result but NO trailing idle — the SDK goes straight to
+    // echoing turn 2. The consumer must settle turn 1 (end_turn) on that echo
+    // (the hand-off path) rather than letting it hang until turn 2's idle.
+    injectTwoTurnSession(agent, [
+      createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false }),
+    ]);
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+
+    await expect(first).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+    await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
   });
 });
 
@@ -4423,9 +4403,6 @@ describe("session/cancel wedge recovery (issue #680)", () => {
         cachedWriteTokens: 0,
       },
       configOptions: [],
-      promptRunning: false,
-      pendingMessages: new Map(),
-      nextPendingOrder: 0,
       abortController: new AbortController(),
       emitRawSDKMessages: false,
       contextWindowSize: 200000,

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4941,6 +4941,9 @@ describe("post-error recovery", () => {
     await expect(second).resolves.toEqual({ stopReason: "cancelled" });
     const compactResult = await compact;
     expect(compactResult.stopReason).toBe("end_turn");
+    // /compact settled with its OWN result (10 tokens), proving the orphan was
+    // skipped — not promoted onto the /compact turn (which would leak its 999).
+    expect(compactResult.usage?.inputTokens).toBe(10);
     await agent.sessions["test-session"]?.consumer;
   });
 });

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -4877,6 +4877,72 @@ describe("post-error recovery", () => {
     expect(thirdResult.usage?.inputTokens).toBe(10);
     await agent.sessions["test-session"]?.consumer;
   });
+
+  it("drains the orphan count, then promotes a no-echo /compact while still cancelled", async () => {
+    // The case that ONLY the orphan-count gate handles (the old `!cancelled`
+    // gate would hang it): cancel removes a queued turn (count=1), its orphan
+    // result drains the count to 0, and THEN a no-echo /compact result arrives
+    // while session.cancelled is still true. The count is 0, so /compact is
+    // promoted (and activating it clears `cancelled`) rather than skipped.
+    const agent = createMockAgent();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => (release = resolve));
+
+    const orphanResult = createResultMessage({
+      subtype: "success",
+      stop_reason: "end_turn",
+      is_error: false,
+    });
+    orphanResult.usage.input_tokens = 999;
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn 1 active
+        await iter.next(); // turn 2's pushed message (cancelled + removed)
+        await gate; // wait until the test cancels (count=1) and sends /compact
+        yield { type: "system", subtype: "session_state_changed", state: "idle" }; // turn 1 settles cancelled
+        yield orphanResult; // turn 2's orphan — drains the count to 0
+        await iter.next(); // /compact's pushed message — never echoes its uuid
+        yield {
+          type: "system",
+          subtype: "status",
+          status: "compacting",
+          session_id: "test-session",
+        };
+        // session.cancelled is STILL true here; the drained count (0) lets this
+        // promote rather than the `!cancelled` gate blocking it.
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    await waitFor(() => (agent.sessions["test-session"]?.turnQueue?.length ?? 0) >= 2);
+
+    await agent.cancel({ sessionId: "test-session" }); // removes turn 2 -> pendingOrphanResults = 1
+    const compact = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact" }],
+    });
+    release();
+
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(second).resolves.toEqual({ stopReason: "cancelled" });
+    const compactResult = await compact;
+    expect(compactResult.stopReason).toBe("end_turn");
+    await agent.sessions["test-session"]?.consumer;
+  });
 });
 
 describe("session/cancel wedge recovery (issue #680)", () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1476,6 +1476,73 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("SDK behavior", () => {
     // message.
     expect(messageIdForGrouping(replayedAssistant!)).toBe(messageStartApiId);
   }, 30000);
+
+  // Pins the two SDK invariants the persistent consumer's lifecycle relies on
+  // (see runConsumer's `done` handling and Session.queryClosed):
+  //   1. A streaming-input query does NOT yield `done` between turns — it stays
+  //      open for the session's life, so a second pushed message starts a
+  //      second turn rather than ending the stream. If this regressed, the
+  //      consumer would tear the session down after the first turn's idle.
+  //   2. Ending the input stream drives the iterator to `done`, and once `done`
+  //      it stays `done` (the iterator is not revivable) — which is what lets us
+  //      treat a `done` as a permanent stream close and reject later prompts
+  //      instead of restarting a consumer over an exhausted query.
+  it("keeps the streaming query open across turns and stays done after input ends", async () => {
+    const sessionId = randomUUID();
+    const input = new Pushable<any>();
+    const q = query({
+      prompt: input,
+      options: {
+        systemPrompt: { type: "preset", preset: "claude_code" },
+        sessionId,
+        includePartialMessages: false,
+        allowedTools: [],
+      },
+    });
+
+    const pushPrompt = (text: string) => {
+      const msg = promptToClaude({ sessionId, prompt: [{ type: "text", text }] });
+      msg.uuid = randomUUID();
+      input.push(msg);
+    };
+
+    // Drain one turn, asserting the stream never ends mid-session, and return
+    // whether the turn produced a `result` before its terminal `idle`.
+    const drainTurn = async () => {
+      let sawResult = false;
+      while (true) {
+        const { value, done } = await q.next();
+        // Invariant 1: the streaming query must not end while a turn is live.
+        expect(done).toBe(false);
+        const message = value as { type: string; subtype?: string; state?: string };
+        if (message.type === "result") sawResult = true;
+        if (
+          message.type === "system" &&
+          message.subtype === "session_state_changed" &&
+          message.state === "idle"
+        ) {
+          return sawResult;
+        }
+      }
+    };
+
+    pushPrompt("Reply with exactly this word and nothing else: one");
+    expect(await drainTurn()).toBe(true);
+
+    // The first turn ended (idle), but the query stays open: pushing a second
+    // user message yields a second turn rather than `done`.
+    pushPrompt("Reply with exactly this word and nothing else: two");
+    expect(await drainTurn()).toBe(true);
+
+    // Invariant 2: ending the input is what terminates the iterator.
+    input.end();
+    const tail = await q.next();
+    expect(tail.done).toBe(true);
+
+    // ...and it stays terminated — a later next() does not revive the stream.
+    const again = await q.next();
+    expect(again.done).toBe(true);
+  }, 60000);
 });
 
 describe("permission requests", () => {
@@ -1862,6 +1929,83 @@ describe("stop reason propagation", () => {
     // The prompt resolves with its OWN result's usage; the background
     // task-notification result's tokens are reported separately (via
     // usage_update), not folded into the user turn's response.
+    expect(response.usage?.inputTokens).toBe(promptResult.usage.input_tokens);
+    expect(response.usage?.outputTokens).toBe(promptResult.usage.output_tokens);
+  });
+
+  it("does not fold a task-notification result's tokens into an already-active turn's usage", async () => {
+    const agent = createMockAgent();
+    const input = new Pushable<any>();
+
+    // A task-notification followup that interleaves AFTER the user turn is
+    // active (its echo seen) but BEFORE the turn's own result. Its tokens must
+    // not leak into the user turn's usage even though the accumulator is only
+    // reset on activation.
+    const backgroundTaskResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+    backgroundTaskResult.usage.input_tokens = 100;
+    backgroundTaskResult.usage.output_tokens = 50;
+    (backgroundTaskResult as { origin?: unknown }).origin = { kind: "task-notification" };
+
+    const promptResult = createResultMessage({
+      subtype: "success",
+      stop_reason: null,
+      is_error: false,
+    });
+
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage } = await iter.next();
+      // User echo first → the turn is now active and its accumulator reset.
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: "test-session",
+        isReplay: true,
+      };
+      // Task-notification result lands mid-turn...
+      yield backgroundTaskResult;
+      // ...then the user turn's own result settles it.
+      yield promptResult;
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+    }
+
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cwd: "/tmp/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/tmp/test", mcpServers: [] }),
+      cancelled: false,
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      abortController: new AbortController(),
+      configOptions: [],
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      toolUseCache: {},
+      messageIdToUuid: new Map(),
+    };
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    expect(response.stopReason).toBe("end_turn");
     expect(response.usage?.inputTokens).toBe(promptResult.usage.input_tokens);
     expect(response.usage?.outputTokens).toBe(promptResult.usage.output_tokens);
   });
@@ -4499,6 +4643,123 @@ describe("post-error recovery", () => {
 
     await expect(first).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
     await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+  });
+
+  function userEcho(u: any) {
+    return {
+      type: "user",
+      message: u.message,
+      parent_tool_use_id: null,
+      uuid: u.uuid,
+      session_id: "test-session",
+      isReplay: true,
+    };
+  }
+
+  function injectGeneratorSession(
+    agent: ClaudeAcpAgent,
+    makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
+  ) {
+    const input = new Pushable<any>();
+    agent.sessions["test-session"] = {
+      query: makeGenerator(input) as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      abortController: new AbortController(),
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      toolUseCache: {},
+      messageIdToUuid: new Map(),
+    } as any;
+    return input;
+  }
+
+  it("does not let a settled turn's lagging idle resolve the next turn early (issue #773 race)", async () => {
+    const agent = createMockAgent();
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        // Turn 1's terminal result settles its prompt() immediately (#773).
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        // Turn 2 is echoed and activated BEFORE turn 1's trailing idle arrives.
+        const u2 = await iter.next();
+        yield userEcho(u2.value);
+        // This lagging idle belongs to turn 1, not turn 2. It must be absorbed,
+        // not used to settle the freshly-activated turn 2 (which would resolve
+        // turn 2 with end_turn and the reset, zero usage before its result).
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+        // Turn 2's own result is what should settle it, carrying real usage.
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    expect(first.stopReason).toBe("end_turn");
+
+    const second = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+    expect(second.stopReason).toBe("end_turn");
+    // If turn 1's lagging idle had settled turn 2, it would have resolved with
+    // the reset (zero) usage before turn 2's result accumulated; turn 2's real
+    // result carries 10 input tokens.
+    expect(second.usage?.inputTokens).toBe(10);
+  });
+
+  it("rejects later prompts after the query stream errors instead of hanging on a dead consumer", async () => {
+    const agent = createMockAgent();
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        // The next prompt drives the stream, which then errors with a
+        // transport failure that is NOT a process death.
+        await iter.next();
+        throw new Error("stream decode error");
+      }
+      return messageGenerator();
+    });
+
+    const first = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    expect(first.stopReason).toBe("end_turn");
+
+    // The in-flight prompt rejects when the stream errors rather than hanging.
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "second" }] }),
+    ).rejects.toThrow();
+
+    // A subsequent prompt rejects up front (the dead consumer is not restarted
+    // on the exhausted stream, which would otherwise hang or fake an end_turn).
+    await expect(
+      agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "third" }] }),
+    ).rejects.toThrow(/start a new session/);
   });
 });
 

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -122,11 +122,13 @@ function mockSessionState(overrides: Record<string, any> = {}) {
 function injectGeneratorSession(
   agent: ClaudeAcpAgent,
   makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
+  overrides: Record<string, any> = {},
 ) {
   const input = new Pushable<any>();
   agent.sessions["test-session"] = mockSessionState({
     query: wrapQuery(makeGenerator(input)),
     input,
+    ...overrides,
   });
   return input;
 }
@@ -1819,36 +1821,10 @@ describe("stop reason propagation", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: {
-        currentModeId: "default",
-        availableModes: [],
-      },
-      models: {
-        currentModelId: "default",
-        availableModels: [],
-      },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   it("should return max_tokens when success result has stop_reason max_tokens", async () => {
@@ -1965,36 +1941,12 @@ describe("stop reason propagation", () => {
       yield { type: "system", subtype: "session_state_changed", state: "idle" };
     }
 
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
       cwd: "/tmp/test",
       sessionFingerprint: JSON.stringify({ cwd: "/tmp/test", mcpServers: [] }),
-      cancelled: false,
-      modes: {
-        currentModeId: "default",
-        availableModes: [],
-      },
-      models: {
-        currentModelId: "default",
-        availableModels: [],
-      },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      abortController: new AbortController(),
-      configOptions: [],
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
 
     const response = await agent.prompt({
       sessionId: "test-session",
@@ -2056,6 +2008,44 @@ describe("stop reason propagation", () => {
     expect(response.usage?.outputTokens).toBe(promptResult.usage.output_tokens);
   });
 
+  it("settles a no-echo command result (e.g. /compact) by promoting the head turn", async () => {
+    // Regression: /compact never echoes a user message carrying the prompt's
+    // uuid (its only user messages are the generated summary and a
+    // <local-command-stdout> replay), so the turn is never activated by an echo.
+    // Its result must still settle the turn — otherwise prompt() hangs forever.
+    const agent = createMockAgent();
+    let releaseIdle!: () => void;
+    const idleGate = new Promise<void>((resolve) => (releaseIdle = resolve));
+
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        await iter.next(); // consume the pushed message but do NOT echo its uuid
+        yield {
+          type: "system",
+          subtype: "status",
+          status: "compacting",
+          session_id: "test-session",
+        };
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        // Hold the stream open past the result so the turn must settle at the
+        // result itself, not via the stream-end (done) fallback or a real idle.
+        await idleGate;
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "/compact" }],
+    });
+    expect(response.stopReason).toBe("end_turn");
+
+    releaseIdle();
+    await agent.sessions["test-session"]?.consumer;
+  });
+
   it("resolves at the terminal result without waiting for a lagging idle (issue #773)", async () => {
     const agent = createMockAgent();
     const input = new Pushable<any>();
@@ -2083,30 +2073,10 @@ describe("stop reason propagation", () => {
       yield { type: "system", subtype: "session_state_changed", state: "idle" };
     }
 
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
 
     const response = await agent.prompt({
       sessionId: "test-session",
@@ -2170,30 +2140,10 @@ describe("stop reason propagation", () => {
       };
     }
 
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
 
     const response = await agent.prompt({
       sessionId: "test-session",
@@ -2739,36 +2689,10 @@ describe("usage_update computation", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: {
-        currentModeId: "default",
-        availableModes: [],
-      },
-      models: {
-        currentModelId: "default",
-        availableModels: [],
-      },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   it("used sums all token types as post-turn context occupancy proxy", async () => {
@@ -3751,30 +3675,10 @@ describe("assembled assistant text fallback", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   function messageChunkTexts(updates: any[]): string[] {
@@ -3944,30 +3848,11 @@ describe("emitRawSDKMessages", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
       emitRawSDKMessages,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   function createResultMessage() {
@@ -4180,30 +4065,10 @@ describe("result origin handling", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   function createAssistantMessage() {
@@ -4354,30 +4219,10 @@ describe("memory_recall handling", () => {
       }
       yield* messages;
     }
-    agent.sessions["test-session"] = {
+    agent.sessions["test-session"] = mockSessionState({
       query: wrapQuery(messageGenerator()),
       input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    });
   }
 
   function createResult() {
@@ -4765,12 +4610,14 @@ describe("post-error recovery", () => {
     ).rejects.toThrow(/start a new session/);
 
     // The broken stream's resources are released even though the session husk
-    // stays in the map for the clear error above: the subprocess/query is
-    // closed, its abort signal fired, and the settings watchers disposed.
+    // stays in the map for the clear error above: the subprocess/query is closed
+    // and the settings watchers disposed. The abortController is left alone — it
+    // may be client-owned, so we don't abort it on a spontaneous stream end (only
+    // teardownSession does, on explicit close).
     const session = agent.sessions["test-session"];
     expect(session.query.close).toHaveBeenCalled();
-    expect(session.abortController.signal.aborted).toBe(true);
     expect(session.settingsManager.dispose).toHaveBeenCalled();
+    expect(session.abortController.signal.aborted).toBe(false);
   });
 
   // Poll a condition across microtask/timer turns, so a test can wait for the
@@ -4845,6 +4692,46 @@ describe("post-error recovery", () => {
     // cancel() must be a no-op and must NOT interrupt the finished query.
     await expect(agent.cancel({ sessionId: "test-session" })).resolves.toBeUndefined();
     expect(agent.sessions["test-session"].query.interrupt).not.toHaveBeenCalled();
+    // A normal stream end closes the query but does NOT abort the (possibly
+    // client-owned) abort controller — only explicit teardown does.
+    expect(agent.sessions["test-session"].query.close).toHaveBeenCalled();
+    expect(agent.sessions["test-session"].abortController.signal.aborted).toBe(false);
+  });
+
+  it("settles a turn that ends via the stream-done path even if releasing resources throws", async () => {
+    const agent = createMockAgent();
+    // The turn is activated by its echo but the stream then ends with NO terminal
+    // result — so it settles in the consumer's `done` branch, not at a result.
+    // settingsManager.dispose() throws during closeQueryStream; because the done
+    // branch settles the turn BEFORE releasing resources, the prompt still
+    // resolves end_turn rather than being rejected when the cleanup failure lands
+    // in the consumer's catch (release-before-settle would reject it).
+    injectGeneratorSession(
+      agent,
+      (input) => {
+        async function* messageGenerator() {
+          const iter = input[Symbol.asyncIterator]();
+          const u1 = await iter.next();
+          yield userEcho(u1.value);
+          // generator returns → done (no result/idle) → done branch settles the
+          // active turn, then closeQueryStream → dispose() throws.
+        }
+        return messageGenerator();
+      },
+      {
+        settingsManager: {
+          dispose: vi.fn(() => {
+            throw new Error("dispose boom");
+          }),
+        },
+      },
+    );
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    expect(response.stopReason).toBe("end_turn");
   });
 
   it("rejects (not 'cancelled') a prompt enqueued after a cancel when the stream then ends", async () => {

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1787,9 +1787,12 @@ describe("stop reason propagation", () => {
       stop_reason: null,
       is_error: false,
     });
-    // Background task used some tokens
+    // Background task used some tokens. Real autonomous followups carry a
+    // task-notification origin, which keeps them out of the user turn's result
+    // and usage.
     backgroundTaskResult.usage.input_tokens = 100;
     backgroundTaskResult.usage.output_tokens = 50;
+    (backgroundTaskResult as { origin?: unknown }).origin = { kind: "task-notification" };
 
     const promptResult = createResultMessage({
       subtype: "success",
@@ -1856,13 +1859,165 @@ describe("stop reason propagation", () => {
     });
 
     expect(response.stopReason).toBe("end_turn");
-    // Usage should include both background task and prompt result tokens
-    expect(response.usage?.inputTokens).toBe(
-      backgroundTaskResult.usage.input_tokens + promptResult.usage.input_tokens,
-    );
-    expect(response.usage?.outputTokens).toBe(
-      backgroundTaskResult.usage.output_tokens + promptResult.usage.output_tokens,
-    );
+    // The prompt resolves with its OWN result's usage; the background
+    // task-notification result's tokens are reported separately (via
+    // usage_update), not folded into the user turn's response.
+    expect(response.usage?.inputTokens).toBe(promptResult.usage.input_tokens);
+    expect(response.usage?.outputTokens).toBe(promptResult.usage.output_tokens);
+  });
+
+  it("resolves at the terminal result without waiting for a lagging idle (issue #773)", async () => {
+    const agent = createMockAgent();
+    const input = new Pushable<any>();
+    // The SDK's trailing `idle` can lag far behind the result while it flushes
+    // held-back results / drains background agents. prompt() must resolve from
+    // the result so the composer unlocks immediately, not block until idle.
+    let releaseIdle!: () => void;
+    const idleGate = new Promise<void>((resolve) => (releaseIdle = resolve));
+    let idleYielded = false;
+
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage } = await iter.next();
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: "test-session",
+        isReplay: true,
+      };
+      yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+      await idleGate;
+      idleYielded = true;
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+    }
+
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      abortController: new AbortController(),
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      toolUseCache: {},
+      messageIdToUuid: new Map(),
+    };
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+
+    // Resolved from the result while idle is still gated.
+    expect(response.stopReason).toBe("end_turn");
+    expect(idleYielded).toBe(false);
+
+    // Releasing the idle lets the consumer drain cleanly without double-settling.
+    releaseIdle();
+    await agent.sessions["test-session"]?.consumer;
+  });
+
+  it("forwards background output that arrives after the turn resolves (issue #679)", async () => {
+    const sessionUpdates: any[] = [];
+    const mockClient = {
+      sessionUpdate: async (u: any) => {
+        sessionUpdates.push(u);
+      },
+    } as unknown as AgentSideConnection;
+    const agent = new ClaudeAcpAgent(mockClient, { log: () => {}, error: () => {} });
+
+    const input = new Pushable<any>();
+    async function* messageGenerator() {
+      const iter = input[Symbol.asyncIterator]();
+      const { value: userMessage } = await iter.next();
+      yield {
+        type: "user",
+        message: userMessage.message,
+        parent_tool_use_id: null,
+        uuid: userMessage.uuid,
+        session_id: "test-session",
+        isReplay: true,
+      };
+      // The user turn completes here — prompt() resolves — and the turn goes
+      // idle. The old per-prompt loop returned at this idle, so anything after
+      // it was not consumed until the next prompt (issue #679).
+      yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+      yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      // Between-turn background output: a top-level assistant message arriving
+      // with no prompt awaiting. The persistent consumer must still forward it.
+      yield {
+        type: "assistant",
+        parent_tool_use_id: null,
+        uuid: randomUUID(),
+        session_id: "test-session",
+        message: {
+          role: "assistant",
+          model: "claude-sonnet-4-5",
+          stop_reason: "end_turn",
+          usage: {
+            input_tokens: 1,
+            output_tokens: 1,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+          },
+          content: [{ type: "text", text: "between-turn background note" }],
+        },
+      };
+    }
+
+    agent.sessions["test-session"] = {
+      query: messageGenerator() as any,
+      input,
+      cancelled: false,
+      cwd: "/test",
+      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+      modes: { currentModeId: "default", availableModes: [] },
+      models: { currentModelId: "default", availableModels: [] },
+      modelInfos: [],
+      settingsManager: { dispose: vi.fn() } as any,
+      accumulatedUsage: {
+        inputTokens: 0,
+        outputTokens: 0,
+        cachedReadTokens: 0,
+        cachedWriteTokens: 0,
+      },
+      configOptions: [],
+      abortController: new AbortController(),
+      emitRawSDKMessages: false,
+      contextWindowSize: 200000,
+      taskState: new Map(),
+      toolUseCache: {},
+      messageIdToUuid: new Map(),
+    };
+
+    const response = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "test" }],
+    });
+    expect(response.stopReason).toBe("end_turn");
+
+    // Drain the consumer so the post-resolution message is processed.
+    await agent.sessions["test-session"]?.consumer;
+
+    const chunkTexts = sessionUpdates
+      .filter((u) => u.update?.sessionUpdate === "agent_message_chunk")
+      .map((u) => u.update.content?.text);
+    expect(chunkTexts).toContain("between-turn background note");
   });
 
   it("should throw internal error for success with is_error true and no max_tokens", async () => {
@@ -3730,6 +3885,9 @@ describe("emitRawSDKMessages", () => {
     );
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+    // prompt() resolves at the turn's result; the trailing idle is forwarded by
+    // the consumer afterward, so wait for it to drain before asserting.
+    await agent.sessions["test-session"]?.consumer;
 
     const sdkMessages = extNotifications.filter((n) => n.method === "_claude/sdkMessage");
     // All system messages should match (compact_boundary + status + session_state_changed)
@@ -3772,6 +3930,9 @@ describe("emitRawSDKMessages", () => {
     );
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+    // The task-notification result arrives after the user-turn result that
+    // resolves prompt(); wait for the consumer to drain it before asserting.
+    await agent.sessions["test-session"]?.consumer;
 
     const sdkMessages = extNotifications.filter((n) => n.method === "_claude/sdkMessage");
     expect(sdkMessages).toHaveLength(1);
@@ -3791,6 +3952,9 @@ describe("emitRawSDKMessages", () => {
     );
 
     await agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "test" }] });
+    // The second (task-notification) result arrives after the one that resolves
+    // prompt(); wait for the consumer to drain it before asserting.
+    await agent.sessions["test-session"]?.consumer;
 
     const sdkMessages = extNotifications.filter((n) => n.method === "_claude/sdkMessage");
     expect(sdkMessages).toHaveLength(2);

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -75,32 +75,29 @@ function userEcho(u: any) {
   };
 }
 
-/** Install a mock session whose query is a caller-supplied async generator
- *  driven by the session's streaming input. Returns the input Pushable so the
- *  test can push additional turns. Centralizes the Session literal so tests that
- *  need bespoke message ordering don't each re-declare it. */
-function injectGeneratorSession(
-  agent: ClaudeAcpAgent,
-  makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
-) {
-  const input = new Pushable<any>();
-  // Wrap the generator with the Query methods cancel()/teardown call, so tests
-  // that exercise cancellation don't hit "interrupt is not a function".
-  const query = Object.assign(makeGenerator(input), {
+/** Wrap a mock async generator with the `Query` methods the agent calls outside
+ *  of iteration — `close()` (teardown/closeQueryStream), `interrupt()` (cancel),
+ *  and `setModel()` — so a bare generator doesn't trip "x is not a function". */
+function wrapQuery(generator: AsyncGenerator<any>) {
+  return Object.assign(generator, {
     interrupt: vi.fn(async () => {}),
     close: vi.fn(),
     setModel: vi.fn(async () => {}),
-  });
-  agent.sessions["test-session"] = {
-    query: query as any,
-    input,
+  }) as any;
+}
+
+/** The common `Session` mock fields, with per-test overrides spread on top.
+ *  Centralizes the boilerplate (usage accumulator, caches, controllers) so a new
+ *  Session field is added in one place rather than every inline literal. */
+function mockSessionState(overrides: Record<string, any> = {}) {
+  return {
     cancelled: false,
     cwd: "/test",
     sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
     modes: { currentModeId: "default", availableModes: [] },
     models: { currentModelId: "default", availableModels: [] },
     modelInfos: [],
-    settingsManager: { dispose: vi.fn() } as any,
+    settingsManager: { dispose: vi.fn() },
     accumulatedUsage: {
       inputTokens: 0,
       outputTokens: 0,
@@ -114,7 +111,23 @@ function injectGeneratorSession(
     taskState: new Map(),
     toolUseCache: {},
     messageIdToUuid: new Map(),
+    ...overrides,
   } as any;
+}
+
+/** Install a mock session whose query is a caller-supplied async generator
+ *  driven by the session's streaming input. Returns the input Pushable so the
+ *  test can push additional turns. Centralizes the Session literal so tests that
+ *  need bespoke message ordering don't each re-declare it. */
+function injectGeneratorSession(
+  agent: ClaudeAcpAgent,
+  makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
+) {
+  const input = new Pushable<any>();
+  agent.sessions["test-session"] = mockSessionState({
+    query: wrapQuery(makeGenerator(input)),
+    input,
+  });
   return input;
 }
 
@@ -1807,7 +1820,7 @@ describe("stop reason propagation", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -1953,7 +1966,7 @@ describe("stop reason propagation", () => {
     }
 
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cwd: "/tmp/test",
       sessionFingerprint: JSON.stringify({ cwd: "/tmp/test", mcpServers: [] }),
@@ -2071,7 +2084,7 @@ describe("stop reason propagation", () => {
     }
 
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -2158,7 +2171,7 @@ describe("stop reason propagation", () => {
     }
 
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -2727,7 +2740,7 @@ describe("usage_update computation", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -3739,7 +3752,7 @@ describe("assembled assistant text fallback", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -3932,7 +3945,7 @@ describe("emitRawSDKMessages", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -4168,7 +4181,7 @@ describe("result origin handling", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -4342,7 +4355,7 @@ describe("memory_recall handling", () => {
       yield* messages;
     }
     agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
+      query: wrapQuery(messageGenerator()),
       input,
       cancelled: false,
       cwd: "/test",
@@ -4750,6 +4763,14 @@ describe("post-error recovery", () => {
     await expect(
       agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "third" }] }),
     ).rejects.toThrow(/start a new session/);
+
+    // The broken stream's resources are released even though the session husk
+    // stays in the map for the clear error above: the subprocess/query is
+    // closed, its abort signal fired, and the settings watchers disposed.
+    const session = agent.sessions["test-session"];
+    expect(session.query.close).toHaveBeenCalled();
+    expect(session.abortController.signal.aborted).toBe(true);
+    expect(session.settingsManager.dispose).toHaveBeenCalled();
   });
 
   // Poll a condition across microtask/timer turns, so a test can wait for the

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -1577,39 +1577,37 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("SDK behavior", () => {
       input.push(msg);
     };
 
-    // Drain one turn, asserting the stream never ends mid-session, and return
-    // whether the turn produced a `result` before its terminal `idle`.
-    const drainTurn = async () => {
-      let sawResult = false;
+    // Drain one turn up to its terminal `result`, asserting the stream stays
+    // open (never `done`) meanwhile. We delimit by `result` — NOT by the
+    // trailing `session_state_changed: idle` — because some CLI binaries don't
+    // emit session-state events (issue #497); waiting on idle would hang there.
+    // This also matches how the consumer itself settles a turn (at the result).
+    const drainToResult = async () => {
       while (true) {
         const { value, done } = await q.next();
         // Invariant 1: the streaming query must not end while a turn is live.
         expect(done).toBe(false);
-        const message = value as { type: string; subtype?: string; state?: string };
-        if (message.type === "result") sawResult = true;
-        if (
-          message.type === "system" &&
-          message.subtype === "session_state_changed" &&
-          message.state === "idle"
-        ) {
-          return sawResult;
-        }
+        if ((value as { type?: string }).type === "result") return;
       }
     };
 
     try {
       pushPrompt("Reply with exactly this word and nothing else: one");
-      expect(await drainTurn()).toBe(true);
+      await drainToResult();
 
-      // The first turn ended (idle), but the query stays open: pushing a second
-      // user message yields a second turn rather than `done`.
+      // The query stays open across turns: a second pushed message yields a
+      // second turn (its own `result`) rather than ending the stream.
       pushPrompt("Reply with exactly this word and nothing else: two");
-      expect(await drainTurn()).toBe(true);
+      await drainToResult();
 
-      // Invariant 2: ending the input is what terminates the iterator.
+      // Invariant 2: ending the input terminates the iterator. Drain any trailing
+      // messages (e.g. a final idle) until it reports `done`.
       input.end();
-      const tail = await q.next();
-      expect(tail.done).toBe(true);
+      let done = false;
+      for (let i = 0; i < 20 && !done; i++) {
+        done = (await q.next()).done ?? false;
+      }
+      expect(done).toBe(true);
 
       // ...and it stays terminated — a later next() does not revive the stream.
       const again = await q.next();

--- a/src/tests/acp-agent.test.ts
+++ b/src/tests/acp-agent.test.ts
@@ -62,6 +62,62 @@ import type {
   BetaCodeExecutionToolResultBlockParam,
 } from "@anthropic-ai/sdk/resources/beta.mjs";
 
+/** Build the replayed `user` message the SDK echoes back for a pushed prompt,
+ *  used by mock generators to promote a turn to active. */
+function userEcho(u: any) {
+  return {
+    type: "user",
+    message: u.message,
+    parent_tool_use_id: null,
+    uuid: u.uuid,
+    session_id: "test-session",
+    isReplay: true,
+  };
+}
+
+/** Install a mock session whose query is a caller-supplied async generator
+ *  driven by the session's streaming input. Returns the input Pushable so the
+ *  test can push additional turns. Centralizes the Session literal so tests that
+ *  need bespoke message ordering don't each re-declare it. */
+function injectGeneratorSession(
+  agent: ClaudeAcpAgent,
+  makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
+) {
+  const input = new Pushable<any>();
+  // Wrap the generator with the Query methods cancel()/teardown call, so tests
+  // that exercise cancellation don't hit "interrupt is not a function".
+  const query = Object.assign(makeGenerator(input), {
+    interrupt: vi.fn(async () => {}),
+    close: vi.fn(),
+    setModel: vi.fn(async () => {}),
+  });
+  agent.sessions["test-session"] = {
+    query: query as any,
+    input,
+    cancelled: false,
+    cwd: "/test",
+    sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
+    modes: { currentModeId: "default", availableModes: [] },
+    models: { currentModelId: "default", availableModels: [] },
+    modelInfos: [],
+    settingsManager: { dispose: vi.fn() } as any,
+    accumulatedUsage: {
+      inputTokens: 0,
+      outputTokens: 0,
+      cachedReadTokens: 0,
+      cachedWriteTokens: 0,
+    },
+    configOptions: [],
+    abortController: new AbortController(),
+    emitRawSDKMessages: false,
+    contextWindowSize: 200000,
+    taskState: new Map(),
+    toolUseCache: {},
+    messageIdToUuid: new Map(),
+  } as any;
+  return input;
+}
+
 describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("ACP subprocess integration", () => {
   let child: ReturnType<typeof spawn>;
 
@@ -1526,22 +1582,29 @@ describe.skipIf(!process.env.RUN_INTEGRATION_TESTS)("SDK behavior", () => {
       }
     };
 
-    pushPrompt("Reply with exactly this word and nothing else: one");
-    expect(await drainTurn()).toBe(true);
+    try {
+      pushPrompt("Reply with exactly this word and nothing else: one");
+      expect(await drainTurn()).toBe(true);
 
-    // The first turn ended (idle), but the query stays open: pushing a second
-    // user message yields a second turn rather than `done`.
-    pushPrompt("Reply with exactly this word and nothing else: two");
-    expect(await drainTurn()).toBe(true);
+      // The first turn ended (idle), but the query stays open: pushing a second
+      // user message yields a second turn rather than `done`.
+      pushPrompt("Reply with exactly this word and nothing else: two");
+      expect(await drainTurn()).toBe(true);
 
-    // Invariant 2: ending the input is what terminates the iterator.
-    input.end();
-    const tail = await q.next();
-    expect(tail.done).toBe(true);
+      // Invariant 2: ending the input is what terminates the iterator.
+      input.end();
+      const tail = await q.next();
+      expect(tail.done).toBe(true);
 
-    // ...and it stays terminated — a later next() does not revive the stream.
-    const again = await q.next();
-    expect(again.done).toBe(true);
+      // ...and it stays terminated — a later next() does not revive the stream.
+      const again = await q.next();
+      expect(again.done).toBe(true);
+    } finally {
+      // Ensure the live CLI subprocess is torn down even if an assertion above
+      // throws before input.end() — otherwise it would outlive the test run.
+      input.end();
+      await q.close?.();
+    }
   }, 60000);
 });
 
@@ -1935,7 +1998,6 @@ describe("stop reason propagation", () => {
 
   it("does not fold a task-notification result's tokens into an already-active turn's usage", async () => {
     const agent = createMockAgent();
-    const input = new Pushable<any>();
 
     // A task-notification followup that interleaves AFTER the user turn is
     // active (its echo seen) but BEFORE the turn's own result. Its tokens must
@@ -1956,49 +2018,20 @@ describe("stop reason propagation", () => {
       is_error: false,
     });
 
-    async function* messageGenerator() {
-      const iter = input[Symbol.asyncIterator]();
-      const { value: userMessage } = await iter.next();
-      // User echo first → the turn is now active and its accumulator reset.
-      yield {
-        type: "user",
-        message: userMessage.message,
-        parent_tool_use_id: null,
-        uuid: userMessage.uuid,
-        session_id: "test-session",
-        isReplay: true,
-      };
-      // Task-notification result lands mid-turn...
-      yield backgroundTaskResult;
-      // ...then the user turn's own result settles it.
-      yield promptResult;
-      yield { type: "system", subtype: "session_state_changed", state: "idle" };
-    }
-
-    agent.sessions["test-session"] = {
-      query: messageGenerator() as any,
-      input,
-      cwd: "/tmp/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/tmp/test", mcpServers: [] }),
-      cancelled: false,
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      abortController: new AbortController(),
-      configOptions: [],
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    };
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const { value: userMessage } = await iter.next();
+        // User echo first → the turn is now active and its accumulator reset.
+        yield userEcho(userMessage);
+        // Task-notification result lands mid-turn...
+        yield backgroundTaskResult;
+        // ...then the user turn's own result settles it.
+        yield promptResult;
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
 
     const response = await agent.prompt({
       sessionId: "test-session",
@@ -2708,7 +2741,7 @@ describe("usage_update computation", () => {
         availableModels: [],
       },
       modelInfos: [],
-      settingsManager: {} as any,
+      settingsManager: { dispose: vi.fn() } as any,
       accumulatedUsage: {
         inputTokens: 0,
         outputTokens: 0,
@@ -4645,49 +4678,6 @@ describe("post-error recovery", () => {
     await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
   });
 
-  function userEcho(u: any) {
-    return {
-      type: "user",
-      message: u.message,
-      parent_tool_use_id: null,
-      uuid: u.uuid,
-      session_id: "test-session",
-      isReplay: true,
-    };
-  }
-
-  function injectGeneratorSession(
-    agent: ClaudeAcpAgent,
-    makeGenerator: (input: Pushable<any>) => AsyncGenerator<any>,
-  ) {
-    const input = new Pushable<any>();
-    agent.sessions["test-session"] = {
-      query: makeGenerator(input) as any,
-      input,
-      cancelled: false,
-      cwd: "/test",
-      sessionFingerprint: JSON.stringify({ cwd: "/test", mcpServers: [] }),
-      modes: { currentModeId: "default", availableModes: [] },
-      models: { currentModelId: "default", availableModels: [] },
-      modelInfos: [],
-      settingsManager: { dispose: vi.fn() } as any,
-      accumulatedUsage: {
-        inputTokens: 0,
-        outputTokens: 0,
-        cachedReadTokens: 0,
-        cachedWriteTokens: 0,
-      },
-      configOptions: [],
-      abortController: new AbortController(),
-      emitRawSDKMessages: false,
-      contextWindowSize: 200000,
-      taskState: new Map(),
-      toolUseCache: {},
-      messageIdToUuid: new Map(),
-    } as any;
-    return input;
-  }
-
   it("does not let a settled turn's lagging idle resolve the next turn early (issue #773 race)", async () => {
     const agent = createMockAgent();
     injectGeneratorSession(agent, (input) => {
@@ -4760,6 +4750,115 @@ describe("post-error recovery", () => {
     await expect(
       agent.prompt({ sessionId: "test-session", prompt: [{ type: "text", text: "third" }] }),
     ).rejects.toThrow(/start a new session/);
+  });
+
+  // Poll a condition across microtask/timer turns, so a test can wait for the
+  // persistent consumer to reach a particular state (e.g. a turn became active,
+  // or the stream closed) without coupling to its internal scheduling.
+  const waitFor = async (cond: () => boolean) => {
+    for (let i = 0; i < 200; i++) {
+      if (cond()) return;
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    throw new Error("waitFor timed out");
+  };
+
+  it("settles a cancelled turn as 'cancelled' even when the next prompt's echo arrives first", async () => {
+    const agent = createMockAgent();
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn 1 active
+        // Turn 1's trailing idle never arrives (the cancel's interrupt is a
+        // no-op here); instead the SDK echoes turn 2 first, forcing the hand-off
+        // path to settle turn 1.
+        const u2 = await iter.next();
+        yield userEcho(u2.value); // turn 2's echo hands off turn 1
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    // Cancel turn 1 while it is the active turn, then send turn 2. Turn 2's echo
+    // hands off turn 1 — which must settle "cancelled", not "end_turn".
+    await agent.cancel({ sessionId: "test-session" });
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(second).resolves.toEqual(expect.objectContaining({ stopReason: "end_turn" }));
+  });
+
+  it("ignores cancel() after the query stream has closed (no interrupt on a dead query)", async () => {
+    const agent = createMockAgent();
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value);
+        yield createResultMessage({ subtype: "success", stop_reason: "end_turn", is_error: false });
+        yield { type: "system", subtype: "session_state_changed", state: "idle" };
+        // generator returns → done → closeQueryStream marks queryClosed.
+      }
+      return messageGenerator();
+    });
+
+    const first = await agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    expect(first.stopReason).toBe("end_turn");
+
+    await waitFor(() => agent.sessions["test-session"]?.queryClosed === true);
+
+    // cancel() must be a no-op and must NOT interrupt the finished query.
+    await expect(agent.cancel({ sessionId: "test-session" })).resolves.toBeUndefined();
+    expect(agent.sessions["test-session"].query.interrupt).not.toHaveBeenCalled();
+  });
+
+  it("rejects (not 'cancelled') a prompt enqueued after a cancel when the stream then ends", async () => {
+    const agent = createMockAgent();
+    let releaseEnd!: () => void;
+    const endGate = new Promise<void>((resolve) => (releaseEnd = resolve));
+    injectGeneratorSession(agent, (input) => {
+      async function* messageGenerator() {
+        const iter = input[Symbol.asyncIterator]();
+        const u1 = await iter.next();
+        yield userEcho(u1.value); // turn 1 active
+        // Hold the stream open until the test has cancelled turn 1 and enqueued
+        // turn 2, then end it WITHOUT ever echoing turn 2.
+        await endGate;
+      }
+      return messageGenerator();
+    });
+
+    const first = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "first" }],
+    });
+    await waitFor(() => !!agent.sessions["test-session"]?.activeTurn);
+
+    await agent.cancel({ sessionId: "test-session" });
+    // Turn 2 is enqueued AFTER the cancel — it was not part of the cancellation.
+    const second = agent.prompt({
+      sessionId: "test-session",
+      prompt: [{ type: "text", text: "second" }],
+    });
+
+    releaseEnd(); // stream ends -> done branch settles turn 1 + rejects turn 2
+
+    await expect(first).resolves.toEqual({ stopReason: "cancelled" });
+    await expect(second).rejects.toThrow(/start a new session/);
   });
 });
 

--- a/src/tests/session-config-options.test.ts
+++ b/src/tests/session-config-options.test.ts
@@ -216,6 +216,31 @@ describe("session config options", () => {
       ).rejects.toThrow("Invalid value for config option mode: invalid-mode");
     });
 
+    it("rejects mode and config changes once the query stream has closed (husk session)", async () => {
+      // After an unexpected stream death the session lingers as a husk
+      // (queryClosed=true) so prompt() can answer with a clear error. The
+      // config/mode handlers must do the same rather than calling setModel/
+      // setPermissionMode on the closed query.
+      const session = (agent as unknown as { sessions: Record<string, { queryClosed?: boolean }> })
+        .sessions[SESSION_ID];
+      session.queryClosed = true;
+
+      await expect(
+        agent.setSessionConfigOption({
+          sessionId: SESSION_ID,
+          configId: "model",
+          value: "claude-sonnet-4-6",
+        }),
+      ).rejects.toThrow(/start a new session/);
+      await expect(agent.setSessionMode({ sessionId: SESSION_ID, modeId: "plan" })).rejects.toThrow(
+        /start a new session/,
+      );
+
+      // Short-circuited before touching the (closed) query.
+      expect(setModelSpy).not.toHaveBeenCalled();
+      expect(setPermissionModeSpy).not.toHaveBeenCalled();
+    });
+
     it("changes mode, sends current_mode_update but not config_option_update", async () => {
       await agent.setSessionConfigOption({
         sessionId: SESSION_ID,


### PR DESCRIPTION
Claude has a lot of background tasks.  If we wait for "idle", some people experience turns that never end. 
If we stop iterating the query after result, people end up with events that never show up.

Given we already often have session_updates outside of the prompt (and clients need to handle it for v2 if they aren't already) this moves the setup to better handle how the SDK gives us this information.

I've been test-driving this build all day and it seems to be working great.

Closes #773
Closes #679
Closes #435
Closes #497
Closes #688
Closes #630

